### PR TITLE
Added selection for counters based on Strava segment efforts

### DIFF
--- a/pages/automations/edit.vue
+++ b/pages/automations/edit.vue
@@ -228,7 +228,7 @@
                             <v-select v-model="recipe.counterProp" label="Activity metadata" class="flex-shrink" :items="counterProps" dense outlined rounded></v-select>
                         </v-col>
                         <v-col v-if="requiredCounterCondition" :cols="$breakpoint.mdAndUp ? 4 : 12" class="mr-md-4">
-                            <v-text-field v-model="recipe.counterCondition" :label="requiredCounterCondition.label" class="flex-shrink" :items="counterProps" dense outlined rounded></v-text-field>
+                            <v-text-field v-model="recipe.counterCondition" :label="requiredCounterCondition.label" class="flex-shrink" dense outlined rounded></v-text-field>
                         </v-col>
                         <v-col :cols="$breakpoint.mdAndUp ? 2 : 12">
                             <v-text-field v-model="recipeStats.counter" type="number" label="Current value" min="0" max="999999" dense outlined rounded></v-text-field>

--- a/pages/automations/edit.vue
+++ b/pages/automations/edit.vue
@@ -227,6 +227,9 @@
                         <v-col :cols="$breakpoint.mdAndUp ? 4 : 12" class="mr-md-4">
                             <v-select v-model="recipe.counterProp" label="Activity metadata" class="flex-shrink" :items="counterProps" dense outlined rounded></v-select>
                         </v-col>
+                        <v-col v-if="requiredCounterCondition" :cols="$breakpoint.mdAndUp ? 4 : 12" class="mr-md-4">
+                            <v-text-field v-model="recipe.counterCondition" :label="requiredCounterCondition.label" class="flex-shrink" :items="counterProps" dense outlined rounded></v-text-field>
+                        </v-col>
                         <v-col :cols="$breakpoint.mdAndUp ? 2 : 12">
                             <v-text-field v-model="recipeStats.counter" type="number" label="Current value" min="0" max="999999" dense outlined rounded></v-text-field>
                         </v-col>
@@ -325,13 +328,16 @@ export default {
             {text: "Distance", value: "distance"},
             {text: "Elevation gain", value: "elevationGain"},
             {text: "Lap count", value: "lapCount"},
+            {text: "Specific segment completion count", value: "segmentCounts"},
             {text: "Segment PR count", value: "prSegments"}
         ]
+        const counterPropsWithCondition = ["segmentCounts"]
         return {
             recipe: null,
             recipeStats: {counter: 0},
             recipePropertiesActions: [],
             counterProps: counterProps,
+            counterPropsWithCondition,
             currentCounter: 0,
             valid: false,
             disabledActions: [],
@@ -365,6 +371,18 @@ export default {
         groupedConditions() {
             if (!this.recipe || !this.recipe.conditions || this.recipe.conditions.length == 0) return null
             return _.groupBy(this.recipe.conditions, "property")
+        },
+        requiredCounterCondition() {
+            if (!this.recipe || !this.recipe.counterProp) return null
+            const requiresCounterCondition = this.counterPropsWithCondition.includes(this.recipe.counterProp)
+            if (!requiresCounterCondition) return null
+
+            switch (this.recipe.counterProp) {
+                case "segmentCounts":
+                    return {label: "Segment ID"}
+                default:
+                    return null
+            }
         }
     },
     watch: {
@@ -376,6 +394,11 @@ export default {
                 this.recipe = recipe
                 this.valid = false
                 this.isNew = true
+            }
+        },
+        requiredCounterCondition: function (newVal) {
+            if (!newVal) {
+                delete this.recipe.counterCondition
             }
         }
     },


### PR DESCRIPTION
This pull request adds the missing frontend configuration changes for https://github.com/strautomator/core/pull/72.

**What I did**

Updated the automation editing page to support a new counter property, "Specific segment completion count", which requires an additional input for a segment ID when selected. The changes ensure the form dynamically displays and manages this extra field only when relevant.

* Added "Specific segment completion count" (`segmentCounts`) to the available counter properties in the `v-select` dropdown.
* Introduced logic to determine if the selected counter property requires an additional input (currently only `segmentCounts`), and display a corresponding `v-text-field` for "Segment ID" when needed. [[1]](diffhunk://#diff-ed0536864f13dd986278d3db74db8b648a92c27a289d699422d08b4a0ea7eb75R230-R232) [[2]](diffhunk://#diff-ed0536864f13dd986278d3db74db8b648a92c27a289d699422d08b4a0ea7eb75R374-R385)
* Ensured that when the required counter condition is no longer needed (e.g., the user switches away from `segmentCounts`), the associated value (`counterCondition`) is removed from the `recipe` object to prevent stale data.