### PR TITLE
Harden OAuth redirects, webhook URLs, and auth checks

### DIFF
--- a/mixins/recipeMixin.js
+++ b/mixins/recipeMixin.js
@@ -209,8 +209,29 @@ export default {
                 },
                 url: (value) => {
                     if (!value) return "Empty URL"
-                    if (/(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/.test(value)) return true
-                    return "Invalid URL"
+
+                    let parsed
+                    try {
+                        parsed = new URL(value)
+                    } catch (ex) {
+                        return "Invalid URL"
+                    }
+
+                    if (parsed.protocol != "http:" && parsed.protocol != "https:") return "Invalid URL"
+                    if (parsed.username || parsed.password) return "Invalid URL"
+
+                    const host = (parsed.hostname || "").replace(/^\[|\]$/g, "").toLowerCase()
+                    if (!host || host.includes(":") || /^\d{1,3}(\.\d{1,3}){3}$/.test(host)) {
+                        return "Webhook URL must be an external domain"
+                    }
+                    if (host == "localhost" || host.endsWith(".localhost") || host.endsWith(".local") || host.endsWith(".internal") || host.endsWith(".localdomain")) {
+                        return "Webhook URL must be an external domain"
+                    }
+                    if (!host.includes(".") || host.startsWith(".") || host.endsWith(".") || host.includes("..") || !/^[a-z0-9.-]+$/.test(host)) {
+                        return "Webhook URL must be an external domain"
+                    }
+
+                    return true
                 }
             }
         }

--- a/modules/oauth/handler.js
+++ b/modules/oauth/handler.js
@@ -32,19 +32,49 @@ Handler.prototype.checkRequestAuthorization = async function checkRequestAuthori
     return false
 }
 
+Handler.prototype.getSafeRedirectUrl = function getSafeRedirectUrl(redirectUrl, defaultRedirect = "/dashboard") {
+    if (!redirectUrl || typeof redirectUrl !== "string") {
+        return defaultRedirect
+    }
+
+    const value = redirectUrl.trim()
+    let path
+
+    // Relative paths must stay on this site (no protocol-relative or backslash tricks).
+    if (value.startsWith("/") && !value.startsWith("//") && !value.startsWith("/\\")) {
+        if (value.includes("\\") || value.includes("://") || /[\r\n\t]/.test(value)) {
+            return defaultRedirect
+        }
+        path = value
+    } else {
+        try {
+            const target = new URL(value)
+            const app = new URL(settings.app.url)
+            if (target.origin !== app.origin) {
+                return defaultRedirect
+            }
+            path = `${target.pathname}${target.search}${target.hash}` || "/"
+        } catch (ex) {
+            return defaultRedirect
+        }
+    }
+
+    // Make sure we never redirect back to home or error pages.
+    const redirectPath = path.replace("/", "").substring(0, 4)
+    if (redirectPath == "home" || redirectPath == "erro" || redirectPath == "auth") {
+        return defaultRedirect
+    }
+
+    return path
+}
+
 Handler.prototype.authenticateCallbackToken = async function authenticateCallbackToken() {
     const defaultRedirect = "/dashboard"
     let redirectUrl
 
     try {
         const {state} = parse(this.req.url.split("?")[1])
-        redirectUrl = atob(state)
-
-        // Make sure we never redirect back to home or error pages.
-        const redirectPath = redirectUrl.replace("/", "").substring(0, 4)
-        if (redirectPath == "home" || redirectPath == "erro" || redirectPath == "auth") {
-            redirectUrl = defaultRedirect
-        }
+        redirectUrl = this.getSafeRedirectUrl(atob(state), defaultRedirect)
     } catch (ex) {
         logger.error("OAuth.authenticateCallbackToken", "Can't parse redirect URL", ex)
         redirectUrl = defaultRedirect
@@ -236,7 +266,7 @@ Handler.prototype.redirectAccessDenied = async function redirectToOAuth() {
 
 Handler.prototype.redirectToOAuth = async function redirectToOAuth(redirectUrl) {
     if (redirectUrl) {
-        redirectUrl = btoa(redirectUrl)
+        redirectUrl = btoa(this.getSafeRedirectUrl(redirectUrl))
     }
 
     return this.redirect(core.strava.getAuthUrl(redirectUrl))

--- a/pages/activities/debug.vue
+++ b/pages/activities/debug.vue
@@ -189,9 +189,16 @@ export default {
         fitDownload() {
             window.open(`/api/strava/${this.user.id}/${this.user.urlToken}/activities/${this.activity.id}/fit`, "_blank")
         },
+        escapeHtml(value) {
+            if (value == null) {
+                return ""
+            }
+
+            return String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;")
+        },
         friendlyValue(value) {
             if (_.isArray(value)) {
-                return value.map((a) => (_.isObject(a) ? Object.values(a).join(": ") : a)).join(", ")
+                return this.escapeHtml(value.map((a) => (_.isObject(a) ? Object.values(a).join(": ") : a)).join(", "))
             }
             if (_.isObject(value)) {
                 const keys = Object.keys(value)
@@ -199,21 +206,22 @@ export default {
                     "<br />" +
                     keys
                         .map((k) => {
+                            const label = this.escapeHtml(k)
                             if (_.isArray(value[k])) {
-                                return `${k}: [${value[k].join(", ")}]`
+                                return `${label}: [${this.escapeHtml(value[k].join(", "))}]`
                             }
                             if (_.isObject(value[k])) {
-                                return `${k}: ${Object.entries(value[k])
-                                    .map(([subK, subV]) => `${subK} = ${subV}`)
+                                return `${label}: ${Object.entries(value[k])
+                                    .map(([subK, subV]) => `${this.escapeHtml(subK)} = ${this.escapeHtml(subV)}`)
                                     .join(", ")}`
                             }
-                            return `${k}: ${value[k]}`
+                            return `${label}: ${this.escapeHtml(value[k])}`
                         })
                         .join("<br />")
                 )
             }
 
-            return value
+            return this.escapeHtml(value)
         }
     }
 }

--- a/src/routes/api/ai.ts
+++ b/src/routes/api/ai.ts
@@ -29,7 +29,7 @@ router.post("/:userId/activity-generate", async (req: express.Request, res: expr
 
         // Rate limit Free accounts to a max of 1 request per provider per hour.
         const rateLimitId = `${user.id}-${provider}`
-        if (user.isPro && rateLimitFree[rateLimitId]) {
+        if (!user.isPro && rateLimitFree[rateLimitId]) {
             const lastRequest = dayjs(rateLimitFree[rateLimitId])
             const nextRequest = lastRequest.add(10, "minutes")
             if (nextRequest.isAfter(dayjs())) {
@@ -60,7 +60,7 @@ router.post("/:userId/activity-generate", async (req: express.Request, res: expr
         const description = await ai.generateActivityDescription(user, {activity, customPrompt, provider, activityWeather})
         user.preferences.language = language
 
-        if (user.isPro) {
+        if (!user.isPro) {
             rateLimitFree[rateLimitId] = new Date()
         }
 

--- a/src/routes/api/shared-recipes.ts
+++ b/src/routes/api/shared-recipes.ts
@@ -1,6 +1,7 @@
 // Strautomator API: Recipes
 
 import {recipes, users, UserData} from "strautomator-core"
+import {validateRecipeWebhookActions} from "../../utils/urls"
 import auth from "../auth"
 import express = require("express")
 import webserver = require("../../webserver")
@@ -55,6 +56,7 @@ router.post("/:userId/:id", async (req: express.Request, res: express.Response) 
         if (!user) return
 
         const data = req.body
+        validateRecipeWebhookActions(data)
         const result = await recipes.setSharedRecipe(user, data)
 
         webserver.renderJson(req, res, result)

--- a/src/routes/api/users.ts
+++ b/src/routes/api/users.ts
@@ -2,6 +2,7 @@
 
 import {logHelper, gdpr, mailer, paddle, paypal, recipes, subscriptions, strava, users, RecipeData, RecipeStatsData, UserData, UserPreferences} from "strautomator-core"
 import {FieldValue} from "@google-cloud/firestore"
+import {validateRecipeWebhookActions} from "../../utils/urls"
 import auth from "../auth"
 import dayjs from "../../dayjs"
 import _ from "lodash"
@@ -470,6 +471,7 @@ const routeUserRecipe = async (req: any, res: any) => {
         if (req.method != "DELETE") {
             try {
                 recipes.validate(user, recipe)
+                validateRecipeWebhookActions(recipe)
             } catch (ex) {
                 if (asJson && ex.message) {
                     ex.message += " (recipe edited as JSON)"

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,6 +1,7 @@
 // Strautomator: Auth
 
 import {logHelper, strava, users, UserData} from "strautomator-core"
+import {isAppOriginUrl} from "../utils/urls"
 import fs = require("fs")
 import logger from "anyhow"
 import webserver = require("../webserver")
@@ -36,7 +37,7 @@ export class Auth {
             if (options.referer) {
                 const referer = req.headers["referer"] || "unknown"
 
-                if (!referer.includes(settings.app.url)) {
+                if (!isAppOriginUrl(referer, settings.app.url)) {
                     logger.error("Auth.requestValidator", req.originalUrl, `Invalid referer: ${referer}`, `From ${req.ip}`)
 
                     res.setHeader("cache-control", "no-cache")

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,0 +1,120 @@
+// URL validation helpers
+
+import net from "net"
+
+const webhookHttpMethods = ["HEAD", "GET", "POST", "PUT", "PATCH", "DELETE"]
+
+/**
+ * Parse a value as a URL and return it, or null if invalid.
+ */
+export const parseUrl = (value: string): URL | null => {
+    if (!value || typeof value != "string") {
+        return null
+    }
+
+    try {
+        return new URL(value.trim())
+    } catch {
+        return null
+    }
+}
+
+/**
+ * Whether the value is an absolute URL on the same origin as settings.app.url.
+ */
+export const isAppOriginUrl = (value: string, appUrl: string): boolean => {
+    const target = parseUrl(value)
+    const app = parseUrl(appUrl)
+
+    if (!target || !app) {
+        return false
+    }
+
+    return target.origin == app.origin
+}
+
+/**
+ * Extract the URL from a webhook action value ("POST https://..." or a bare URL).
+ */
+export const extractWebhookUrl = (actionValue: string): string => {
+    const strValue = (actionValue || "").trim()
+    if (!strValue) {
+        return ""
+    }
+
+    const arrValue = strValue.split(" ")
+    if (arrValue.length == 1) {
+        return arrValue[0]
+    }
+
+    const method = arrValue[0].toUpperCase()
+    if (webhookHttpMethods.includes(method)) {
+        return arrValue.slice(1).join("")
+    }
+
+    return strValue
+}
+
+/**
+ * Whether a hostname is a public domain name (not an IP or local/internal host).
+ */
+export const isExternalDomainHost = (hostname: string): boolean => {
+    if (!hostname || typeof hostname != "string") {
+        return false
+    }
+
+    const host = hostname.replace(/^\[|\]$/g, "").toLowerCase()
+    if (!host || host.includes(":") || net.isIP(host)) {
+        return false
+    }
+
+    if (host == "localhost" || host.endsWith(".localhost") || host.endsWith(".local") || host.endsWith(".internal") || host.endsWith(".localdomain")) {
+        return false
+    }
+
+    if (!host.includes(".") || host.startsWith(".") || host.endsWith(".") || host.includes("..")) {
+        return false
+    }
+
+    if (!/^[a-z0-9.-]+$/.test(host)) {
+        return false
+    }
+
+    return true
+}
+
+/**
+ * Whether the value is an http(s) URL pointing at an external domain (not an IP).
+ */
+export const isExternalDomainUrl = (value: string): boolean => {
+    const parsed = parseUrl(value)
+    if (!parsed) {
+        return false
+    }
+
+    if (parsed.protocol != "http:" && parsed.protocol != "https:") {
+        return false
+    }
+
+    if (parsed.username || parsed.password) {
+        return false
+    }
+
+    return isExternalDomainHost(parsed.hostname)
+}
+
+/**
+ * Validate webhook actions on a recipe. Throws if any webhook URL is not an external domain.
+ */
+export const validateRecipeWebhookActions = (recipe: {actions?: {type?: string; value?: string}[]}): void => {
+    for (let action of recipe?.actions || []) {
+        if (action.type != "webhook") {
+            continue
+        }
+
+        const webhookUrl = extractWebhookUrl(action.value || "")
+        if (!isExternalDomainUrl(webhookUrl)) {
+            throw new Error("Webhook URL must be an external domain (IP addresses are not allowed)")
+        }
+    }
+}

--- a/src/webserver.ts
+++ b/src/webserver.ts
@@ -140,6 +140,8 @@ class WebServer {
                         } else {
                             res.end()
                         }
+
+                        return
                     }
                     next()
                 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes several issues from the web security review.

### Changes
- **OAuth callback redirects** only allow same-origin or relative paths. External domains, protocol-relative URLs, and the existing `/home` `/error` `/auth` prefixes fall back to `/dashboard`.
- **Automation webhook URLs** must be `http(s)` to an external domain. IPs, localhost, `.local` / `.internal` hosts, and URLs with credentials are rejected in the API (user + shared recipes) and in the recipe form validator.
- **`requireCloudflare`** returns after a 401 so the request does not continue into API routes.
- **Referer checks** compare `new URL(referer).origin` to `new URL(settings.app.url).origin` instead of a substring match.
- **AI generate limiter** now applies to free accounts, not PRO.
- **Activity debug `friendlyValue()`** HTML-escapes keys and values before `v-html`.

Strava user tokens, the shared `urlToken`, and the production cookie secret were left as-is.

### Tested
Unit checks for origin matching, webhook URL allow/deny, OAuth redirect sanitization, Cloudflare control flow, AI limiter polarity, and HTML escaping. The live debug page was not exercised (needs a running app with Strava credentials).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5ab95ac-8089-4549-9ccd-3ae121421b77?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5ab95ac-8089-4549-9ccd-3ae121421b77&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

