### PR TITLE
Add a spec-compliant MCP server for PRO members

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ To properly test all APIs and webhooks from Strava and PayPal, you'll need to ch
 
 If for whatever reason you want to split the Strautomator API from the frontend, you can use the `api.url` setting to specify the base path for the API. By default, it runs on the `/api/` path under the same URL set on the `app.url`.
 
+### MCP server
+
+The web app also hosts a remote MCP server at `/mcp` for PRO members. MCP clients (Cursor, Claude, etc.) authenticate with OAuth 2.1:
+
+- Protected resource metadata: `/.well-known/oauth-protected-resource`
+- Authorization server metadata: `/.well-known/oauth-authorization-server`
+- Dynamic client registration: `/mcp/oauth/register`
+- Authorization (Strava login + consent): `/mcp/oauth/authorize`
+- Token + PKCE: `/mcp/oauth/token`
+
+Users stay on Strava for identity. The MCP authorization server issues its own tokens (audience-bound to `/mcp`) and never accepts or forwards Strava access tokens. Connect from an MCP client using the server URL `https://strautomator.com/mcp`.
+
 If you plan to deploy the instance to production and build the nuxt app beforehand, it's mandatory to set the app URL via the environment variable `$SMU_app_url`.
 
 ### Cloudflare Tunnel

--- a/components/FreeProTable.vue
+++ b/components/FreeProTable.vue
@@ -57,6 +57,11 @@
                         <td class="text-center"><v-icon>mdi-checkbox-marked-circle-outline</v-icon></td>
                     </tr>
                     <tr>
+                        <td>MCP server</td>
+                        <td class="text-center"><v-icon>mdi-checkbox-blank-circle-outline</v-icon></td>
+                        <td class="text-center"><v-icon>mdi-checkbox-marked-circle-outline</v-icon></td>
+                    </tr>
+                    <tr>
                         <td>Shared automations</td>
                         <td class="text-center"><v-icon>mdi-checkbox-blank-circle-outline</v-icon></td>
                         <td class="text-center"><v-icon>mdi-checkbox-marked-circle-outline</v-icon></td>

--- a/pages/account/index.vue
+++ b/pages/account/index.vue
@@ -94,6 +94,27 @@
                 </v-alert>
             </div>
             <v-card class="mt-5" outlined>
+                <v-card-title class="accent">MCP{{ user.isPro ? "" : " (PRO only)" }}</v-card-title>
+                <v-card-text class="pt-4">
+                    <div class="body-2">
+                        Connect Cursor, Claude or other MCP clients to your Strautomator account. You will be asked to sign in with Strava and authorize the client. MCP access is limited to PRO members.
+                    </div>
+                    <template v-if="user.isPro">
+                        <div class="mt-3 text-caption">Server URL</div>
+                        <code class="d-inline-block mt-1 pa-2">{{ mcpUrl }}</code>
+                        <div class="mt-3">
+                            <v-btn color="primary" title="Copy MCP URL" @click="copyMcpUrl" outlined rounded small>
+                                <v-icon left>mdi-content-copy</v-icon>
+                                {{ mcpCopied ? "Copied" : "Copy URL" }}
+                            </v-btn>
+                        </div>
+                    </template>
+                    <div class="mt-3" v-else>
+                        <n-link to="/billing" title="Upgrade to PRO" nuxt>Upgrade to PRO</n-link> to enable the MCP server.
+                    </div>
+                </v-card-text>
+            </v-card>
+            <v-card class="mt-5" outlined>
                 <v-card-title class="accent">My preferences</v-card-title>
                 <v-card-text>
                     <h3 class="mb-2 mt-5">Weather settings</h3>
@@ -640,7 +661,8 @@ export default {
                 {value: "pt", text: "Português"},
                 {value: "se", text: "Svenska"},
                 {value: "sk", text: "Slovenčina"}
-            ]
+            ],
+            mcpCopied: false
         }
     },
     computed: {
@@ -663,6 +685,10 @@ export default {
         dateResetCounterFormatted() {
             const result = this.$dayjs(this.dateResetCounter)
             return result.format("MMM DD")
+        },
+        mcpUrl() {
+            const base = (this.$axios.defaults.baseURL || "").replace(/\/+$/, "")
+            return `${base}/mcp`
         }
     },
     watch: {
@@ -738,6 +764,17 @@ export default {
             if (newValue != oldValue) {
                 this.savePending = true
                 this.delaySavePreferences()
+            }
+        },
+        async copyMcpUrl() {
+            try {
+                await navigator.clipboard.writeText(this.mcpUrl)
+                this.mcpCopied = true
+                setTimeout(() => {
+                    this.mcpCopied = false
+                }, 2500)
+            } catch (ex) {
+                this.$webError(this, "Account.copyMcpUrl", ex)
             }
         },
         hideEmailDialog(emailSaved) {

--- a/src/mcp/html.ts
+++ b/src/mcp/html.ts
@@ -1,0 +1,71 @@
+// Strautomator MCP HTML pages (consent / errors)
+
+import {escapeHtml, getMcpConfig} from "./utils"
+
+const layout = (title: string, body: string): string => {
+    const config = getMcpConfig()
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escapeHtml(title)} - Strautomator</title>
+    <style>
+        body { margin: 0; font-family: "Roboto", "Helvetica Neue", Arial, sans-serif; background: #121212; color: #eee; }
+        .stripe { height: 6px; background: #ff8f00; }
+        .wrap { max-width: 560px; margin: 48px auto; padding: 0 20px; }
+        h1 { font-weight: 300; font-size: 1.6rem; margin: 0 0 8px; }
+        h2 { font-weight: 700; font-size: 1.9rem; margin: 0 0 24px; color: #ffb74d; }
+        p { line-height: 1.5; color: #ccc; }
+        .card { background: #1e1e1e; border: 1px solid #333; border-radius: 12px; padding: 24px; }
+        .row { margin: 16px 0; }
+        .actions { display: flex; gap: 12px; justify-content: flex-end; margin-top: 24px; }
+        button, .btn { appearance: none; border: 0; border-radius: 24px; padding: 10px 20px; font-size: 14px; cursor: pointer; text-decoration: none; display: inline-block; }
+        .primary { background: #ff8f00; color: #111; font-weight: 600; }
+        .ghost { background: transparent; color: #bbb; border: 1px solid #555; }
+        .muted { color: #999; font-size: 13px; }
+        a { color: #ffb74d; }
+    </style>
+</head>
+<body>
+    <div class="stripe"></div>
+    <div class="wrap">
+        <h1>Strautomator</h1>
+        ${body}
+        <p class="muted">MCP endpoint: ${escapeHtml(config.resource)}</p>
+    </div>
+</body>
+</html>`
+}
+
+export const consentPage = (options: {clientName: string; userName: string; requestId: string; consentToken: string}): string => {
+    const clientName = escapeHtml(options.clientName || "An MCP client")
+    const userName = escapeHtml(options.userName || "your account")
+
+    return layout(
+        "Authorize MCP access",
+        `<h2>Authorize access</h2>
+        <div class="card">
+            <p><strong>${clientName}</strong> wants to access Strautomator as <strong>${userName}</strong>.</p>
+            <p>This lets the client read your activities, automations and GearWear, and make changes that you already can make in the Strautomator app. Access is limited to PRO members.</p>
+            <form method="post" action="/mcp/oauth/authorize">
+                <input type="hidden" name="request_id" value="${escapeHtml(options.requestId)}" />
+                <input type="hidden" name="consent_token" value="${escapeHtml(options.consentToken)}" />
+                <div class="actions">
+                    <button class="ghost" type="submit" name="decision" value="deny">Deny</button>
+                    <button class="primary" type="submit" name="decision" value="approve">Authorize</button>
+                </div>
+            </form>
+        </div>`
+    )
+}
+
+export const errorPage = (title: string, message: string, href?: string, hrefLabel?: string): string => {
+    const link = href ? `<p><a class="btn primary" href="${escapeHtml(href)}">${escapeHtml(hrefLabel || "Continue")}</a></p>` : ""
+    return layout(title, `<h2>${escapeHtml(title)}</h2><div class="card"><p>${escapeHtml(message)}</p>${link}</div>`)
+}
+
+export const proRequiredPage = (): string => {
+    return errorPage("PRO required", "The Strautomator MCP server is available to PRO members only. Upgrade your account, then try connecting again.", "/billing", "Go to billing")
+}
+

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,53 @@
+// Strautomator MCP HTTP routes
+
+import * as oauth from "./oauth"
+import {handleMcp} from "./protocol"
+import {setCorsHeaders} from "./utils"
+import express = require("express")
+import logger from "anyhow"
+
+const corsPreflight = (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    setCorsHeaders(res)
+    if (req.method == "OPTIONS") {
+        res.status(204).send()
+        return
+    }
+    next()
+}
+
+/**
+ * Register MCP and OAuth endpoints on the Express app. Must run before the Nuxt renderer.
+ */
+const setup = (app: express.Express): void => {
+    const wellKnown = express.Router()
+    wellKnown.use(corsPreflight)
+    wellKnown.get("/oauth-protected-resource", oauth.protectedResourceMetadata)
+    wellKnown.get("/oauth-protected-resource/mcp", oauth.protectedResourceMetadata)
+    wellKnown.get("/oauth-authorization-server", oauth.authorizationServerMetadata)
+    wellKnown.get("/oauth-authorization-server/mcp", oauth.authorizationServerMetadata)
+    app.use("/.well-known", wellKnown)
+
+    const oauthRouter = express.Router()
+    oauthRouter.use(corsPreflight)
+    oauthRouter.get("/authorize", oauth.authorize)
+    oauthRouter.post("/authorize", oauth.authorize)
+    oauthRouter.post("/register", oauth.registerClient)
+    oauthRouter.post("/token", oauth.token)
+    oauthRouter.post("/revoke", oauth.revoke)
+    app.use("/mcp/oauth", oauthRouter)
+
+    const mcpMeta = express.Router()
+    mcpMeta.use(corsPreflight)
+    mcpMeta.get("/oauth-protected-resource", oauth.protectedResourceMetadata)
+    mcpMeta.get("/oauth-authorization-server", oauth.authorizationServerMetadata)
+    app.use("/mcp/.well-known", mcpMeta)
+
+    app.options("/mcp", corsPreflight)
+    app.get("/mcp", corsPreflight, handleMcp)
+    app.post("/mcp", corsPreflight, handleMcp)
+    app.delete("/mcp", corsPreflight, handleMcp)
+
+    logger.info("Mcp.setup", "MCP server routes registered at /mcp")
+}
+
+export = {setup}

--- a/src/mcp/oauth.ts
+++ b/src/mcp/oauth.ts
@@ -1,0 +1,440 @@
+// Strautomator MCP OAuth 2.1 authorization server
+
+import {users, UserData} from "strautomator-core"
+import {consentPage, errorPage, proRequiredPage} from "./html"
+import store from "./store"
+import {McpAuthRequest, McpOAuthClient} from "./types"
+import {firstString, getMcpConfig, hashToken, isValidRedirectUri, randomToken, setCorsHeaders, verifyPkce} from "./utils"
+import crypto from "crypto"
+import express = require("express")
+import logger from "anyhow"
+import dayjs from "../dayjs"
+const sessions = require("client-sessions")
+
+const supportedGrantTypes = ["authorization_code", "refresh_token"]
+const supportedResponseTypes = ["code"]
+const supportedAuthMethods = ["none", "client_secret_post", "client_secret_basic"]
+
+let sessionMiddleware: express.RequestHandler
+
+const getSessionMiddleware = (): express.RequestHandler => {
+    if (!sessionMiddleware) {
+        const config = getMcpConfig()
+        sessionMiddleware = sessions({
+            cookieName: config.cookieName,
+            secret: config.cookieSecret,
+            duration: 7 * 24 * 60 * 60 * 1000
+        })
+    }
+    return sessionMiddleware
+}
+
+const withSession = (handler: express.RequestHandler): express.RequestHandler => {
+    return (req, res, next) => {
+        getSessionMiddleware()(req, res, () => handler(req, res, next))
+    }
+}
+
+const oauthRedirect = (res: express.Response, redirectUri: string, params: Record<string, string>): void => {
+    const url = new URL(redirectUri)
+    for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined && value !== null && value !== "") {
+            url.searchParams.set(key, value)
+        }
+    }
+    res.redirect(302, url.toString())
+}
+
+const oauthErrorJson = (res: express.Response, status: number, error: string, description: string): void => {
+    res.status(status).json({error, error_description: description})
+}
+
+const parseBasicClient = (req: express.Request): {clientId?: string; clientSecret?: string} => {
+    const header = req.headers.authorization || ""
+    if (!header.toLowerCase().startsWith("basic ")) {
+        return {}
+    }
+
+    try {
+        const decoded = Buffer.from(header.substring(6).trim(), "base64").toString("utf8")
+        const idx = decoded.indexOf(":")
+        if (idx < 0) {
+            return {clientId: decoded}
+        }
+        return {clientId: decoded.substring(0, idx), clientSecret: decoded.substring(idx + 1)}
+    } catch {
+        return {}
+    }
+}
+
+const authenticateClient = async (req: express.Request): Promise<{client: McpOAuthClient; error?: string}> => {
+    const basic = parseBasicClient(req)
+    const clientId = firstString(req.body?.client_id) || basic.clientId
+    const clientSecret = firstString(req.body?.client_secret) || basic.clientSecret
+    const client = await store.getClient(clientId)
+
+    if (!client) {
+        return {client: null, error: "invalid_client"}
+    }
+
+    if (client.tokenEndpointAuthMethod == "none") {
+        return {client}
+    }
+
+    if (!client.clientSecretHash || !clientSecret) {
+        return {client: null, error: "invalid_client"}
+    }
+    const expected = Buffer.from(client.clientSecretHash)
+    const actual = Buffer.from(hashToken(clientSecret))
+    if (expected.length != actual.length || !crypto.timingSafeEqual(expected, actual)) {
+        return {client: null, error: "invalid_client"}
+    }
+
+    return {client}
+}
+
+const getLoggedUser = async (req: express.Request): Promise<UserData> => {
+    const config = getMcpConfig()
+    const session = (req as any)[config.cookieName]
+    const userId = session?.userId
+    if (!userId) {
+        return null
+    }
+
+    try {
+        return await users.getById(userId)
+    } catch (ex) {
+        logger.warn("McpOAuth.getLoggedUser", userId, ex)
+        return null
+    }
+}
+
+const resourceMatches = (requested: string, expected: string): boolean => {
+    if (!requested) {
+        return true
+    }
+    const a = requested.replace(/\/+$/, "")
+    const b = expected.replace(/\/+$/, "")
+    return a == b
+}
+
+/**
+ * Protected resource metadata (RFC 9728).
+ */
+export const protectedResourceMetadata = (_req: express.Request, res: express.Response): void => {
+    const config = getMcpConfig()
+    setCorsHeaders(res)
+    res.json({
+        resource: config.resource,
+        authorization_servers: [config.issuer],
+        bearer_methods_supported: ["header"],
+        scopes_supported: [config.scope],
+        resource_name: "Strautomator MCP"
+    })
+}
+
+/**
+ * Authorization server metadata (RFC 8414).
+ */
+export const authorizationServerMetadata = (_req: express.Request, res: express.Response): void => {
+    const config = getMcpConfig()
+    setCorsHeaders(res)
+    res.json({
+        issuer: config.issuer,
+        authorization_endpoint: `${config.issuer}/mcp/oauth/authorize`,
+        token_endpoint: `${config.issuer}/mcp/oauth/token`,
+        registration_endpoint: `${config.issuer}/mcp/oauth/register`,
+        revocation_endpoint: `${config.issuer}/mcp/oauth/revoke`,
+        scopes_supported: [config.scope],
+        response_types_supported: supportedResponseTypes,
+        grant_types_supported: supportedGrantTypes,
+        token_endpoint_auth_methods_supported: supportedAuthMethods,
+        revocation_endpoint_auth_methods_supported: supportedAuthMethods,
+        code_challenge_methods_supported: ["S256"],
+        resource_indicators_supported: true
+    })
+}
+
+/**
+ * Dynamic client registration (RFC 7591).
+ */
+export const registerClient = async (req: express.Request, res: express.Response): Promise<void> => {
+    try {
+        setCorsHeaders(res)
+
+        const body = req.body || {}
+        const redirectUris: string[] = Array.isArray(body.redirect_uris) ? body.redirect_uris : []
+        if (redirectUris.length < 1) {
+            return oauthErrorJson(res, 400, "invalid_redirect_uri", "redirect_uris is required")
+        }
+        if (redirectUris.some((uri) => !isValidRedirectUri(uri))) {
+            return oauthErrorJson(res, 400, "invalid_redirect_uri", "One or more redirect_uris are not allowed")
+        }
+
+        const grantTypes: string[] = Array.isArray(body.grant_types) && body.grant_types.length > 0 ? body.grant_types : ["authorization_code", "refresh_token"]
+        if (grantTypes.some((g) => !supportedGrantTypes.includes(g))) {
+            return oauthErrorJson(res, 400, "invalid_client_metadata", "Unsupported grant_types")
+        }
+
+        const responseTypes: string[] = Array.isArray(body.response_types) && body.response_types.length > 0 ? body.response_types : ["code"]
+        if (responseTypes.some((r) => !supportedResponseTypes.includes(r))) {
+            return oauthErrorJson(res, 400, "invalid_client_metadata", "Unsupported response_types")
+        }
+
+        let tokenEndpointAuthMethod = firstString(body.token_endpoint_auth_method) || "none"
+        if (!supportedAuthMethods.includes(tokenEndpointAuthMethod)) {
+            return oauthErrorJson(res, 400, "invalid_client_metadata", "Unsupported token_endpoint_auth_method")
+        }
+
+        const config = getMcpConfig()
+        const now = dayjs()
+        const clientId = `st_${crypto.randomBytes(16).toString("hex")}`
+        const confidential = tokenEndpointAuthMethod != "none"
+        const clientSecret = confidential ? randomToken(32) : null
+
+        const client: McpOAuthClient = {
+            id: clientId,
+            clientName: firstString(body.client_name).substring(0, 120) || undefined,
+            clientSecretHash: clientSecret ? hashToken(clientSecret) : undefined,
+            tokenEndpointAuthMethod: tokenEndpointAuthMethod as McpOAuthClient["tokenEndpointAuthMethod"],
+            redirectUris,
+            grantTypes,
+            responseTypes,
+            dateIssued: now.toDate(),
+            dateExpiry: now.add(config.clientDays, "days").toDate()
+        }
+
+        await store.saveClient(client)
+
+        const result: any = {
+            client_id: client.id,
+            client_id_issued_at: now.unix(),
+            client_secret_expires_at: 0,
+            redirect_uris: client.redirectUris,
+            grant_types: client.grantTypes,
+            response_types: client.responseTypes,
+            token_endpoint_auth_method: client.tokenEndpointAuthMethod,
+            client_name: client.clientName
+        }
+        if (clientSecret) {
+            result.client_secret = clientSecret
+        }
+
+        logger.info("McpOAuth.registerClient", client.id, client.clientName || "unnamed", `${redirectUris.length} redirect URIs`)
+        res.status(201).json(result)
+    } catch (ex) {
+        logger.error("McpOAuth.registerClient", ex)
+        oauthErrorJson(res, 500, "server_error", "Failed to register client")
+    }
+}
+
+const createAuthRequest = async (req: express.Request): Promise<{request?: McpAuthRequest; error?: string; description?: string; redirectUri?: string; state?: string}> => {
+    const config = getMcpConfig()
+    const clientId = firstString(req.query.client_id)
+    const redirectUri = firstString(req.query.redirect_uri)
+    const responseType = firstString(req.query.response_type) || "code"
+    const state = firstString(req.query.state)
+    const codeChallenge = firstString(req.query.code_challenge)
+    const codeChallengeMethod = firstString(req.query.code_challenge_method)
+    const resource = firstString(req.query.resource) || config.resource
+    const client = await store.getClient(clientId)
+    if (!client) {
+        return {error: "invalid_client", description: "Unknown client_id"}
+    }
+    if (!client.redirectUris.includes(redirectUri)) {
+        return {error: "invalid_request", description: "redirect_uri is not registered for this client"}
+    }
+    if (responseType != "code") {
+        return {error: "unsupported_response_type", description: "Only response_type=code is supported", redirectUri, state}
+    }
+    if (!codeChallenge || codeChallengeMethod.toUpperCase() != "S256") {
+        return {error: "invalid_request", description: "PKCE S256 is required", redirectUri, state}
+    }
+    if (!resourceMatches(resource, config.resource)) {
+        return {error: "invalid_target", description: "resource does not match this MCP server", redirectUri, state}
+    }
+
+    const request: McpAuthRequest = {
+        id: randomToken(18),
+        clientId: client.id,
+        redirectUri,
+        state,
+        codeChallenge,
+        codeChallengeMethod: "S256",
+        resource: config.resource,
+        scope: config.scope,
+        consentToken: randomToken(18),
+        dateExpiry: dayjs().add(config.authRequestMinutes, "minutes").toDate()
+    }
+    await store.saveAuthRequest(request)
+    return {request}
+}
+
+/**
+ * Authorization endpoint (authorization code + PKCE). GET shows consent; POST records the decision.
+ */
+export const authorize = withSession(async (req: express.Request, res: express.Response): Promise<void> => {
+    const config = getMcpConfig()
+
+    try {
+        let request: McpAuthRequest
+        const requestId = firstString(req.body?.request_id) || firstString(req.query.request_id)
+
+        if (requestId) {
+            request = await store.getAuthRequest(requestId)
+            if (!request) {
+                res.status(400).send(errorPage("Authorization expired", "This authorization request is no longer valid. Start the connection again from your MCP client."))
+                return
+            }
+        } else if (req.method == "GET") {
+            const created = await createAuthRequest(req)
+            if (created.error) {
+                if (created.redirectUri) {
+                    oauthRedirect(res, created.redirectUri, {error: created.error, error_description: created.description, state: created.state, iss: config.issuer})
+                    return
+                }
+                res.status(400).send(errorPage("Invalid request", created.description || created.error))
+                return
+            }
+            request = created.request
+        } else {
+            res.status(400).send(errorPage("Invalid request", "Missing authorization request."))
+            return
+        }
+
+        const user = await getLoggedUser(req)
+        if (!user) {
+            const returnPath = `/mcp/oauth/authorize?request_id=${encodeURIComponent(request.id)}`
+            res.redirect(302, `/auth/login?redirect-url=${encodeURIComponent(returnPath)}`)
+            return
+        }
+        if (!user.isPro) {
+            res.status(403).send(proRequiredPage())
+            return
+        }
+
+        if (req.method == "POST") {
+            const consentToken = firstString(req.body?.consent_token)
+            const decision = firstString(req.body?.decision)
+            if (!consentToken || consentToken != request.consentToken) {
+                res.status(400).send(errorPage("Invalid request", "The consent form could not be validated. Please try again."))
+                return
+            }
+
+            await store.deleteAuthRequest(request.id)
+
+            if (decision != "approve") {
+                oauthRedirect(res, request.redirectUri, {error: "access_denied", error_description: "The user denied the request", state: request.state, iss: config.issuer})
+                return
+            }
+
+            const code = await store.issueAuthCode({
+                clientId: request.clientId,
+                userId: user.id,
+                redirectUri: request.redirectUri,
+                codeChallenge: request.codeChallenge,
+                resource: request.resource,
+                scope: request.scope,
+                dateExpiry: dayjs().add(config.authCodeMinutes, "minutes").toDate()
+            })
+
+            logger.info("McpOAuth.authorize", `User ${user.id}`, `Client ${request.clientId}`, "Authorized")
+            oauthRedirect(res, request.redirectUri, {code, state: request.state, iss: config.issuer})
+            return
+        }
+
+        const client = await store.getClient(request.clientId)
+        res.send(consentPage({clientName: client?.clientName || "MCP client", userName: user.displayName || user.id, requestId: request.id, consentToken: request.consentToken}))
+    } catch (ex) {
+        logger.error("McpOAuth.authorize", ex)
+        res.status(500).send(errorPage("Server error", "Could not complete the authorization request."))
+    }
+})
+
+/**
+ * Token endpoint.
+ */
+export const token = async (req: express.Request, res: express.Response): Promise<void> => {
+    setCorsHeaders(res)
+    res.setHeader("Cache-Control", "no-store")
+    res.setHeader("Pragma", "no-cache")
+
+    try {
+        const auth = await authenticateClient(req)
+        if (!auth.client) {
+            res.setHeader("WWW-Authenticate", "Basic realm=\"mcp\"")
+            return oauthErrorJson(res, 401, "invalid_client", "Client authentication failed")
+        }
+
+        const grantType = firstString(req.body?.grant_type)
+        if (grantType == "authorization_code") {
+            const code = firstString(req.body?.code)
+            const redirectUri = firstString(req.body?.redirect_uri)
+            const codeVerifier = firstString(req.body?.code_verifier)
+            const resource = firstString(req.body?.resource)
+            const authCode = await store.consumeAuthCode(code)
+
+            if (!authCode || authCode.clientId != auth.client.id) {
+                return oauthErrorJson(res, 400, "invalid_grant", "Invalid authorization code")
+            }
+            if (authCode.redirectUri != redirectUri) {
+                return oauthErrorJson(res, 400, "invalid_grant", "redirect_uri mismatch")
+            }
+            if (!verifyPkce(codeVerifier, authCode.codeChallenge)) {
+                return oauthErrorJson(res, 400, "invalid_grant", "PKCE verification failed")
+            }
+            if (resource && !resourceMatches(resource, authCode.resource)) {
+                return oauthErrorJson(res, 400, "invalid_target", "resource mismatch")
+            }
+
+            const tokens = await store.issueTokens({clientId: auth.client.id, userId: authCode.userId, resource: authCode.resource, scope: authCode.scope})
+            logger.info("McpOAuth.token", `User ${authCode.userId}`, `Client ${auth.client.id}`, "authorization_code")
+            res.json({access_token: tokens.accessToken, token_type: "Bearer", expires_in: tokens.expiresIn, refresh_token: tokens.refreshToken, scope: authCode.scope})
+            return
+        }
+
+        if (grantType == "refresh_token") {
+            const refreshToken = firstString(req.body?.refresh_token)
+            const resource = firstString(req.body?.resource)
+            const existing = await store.consumeRefreshToken(refreshToken)
+
+            if (!existing || existing.clientId != auth.client.id) {
+                return oauthErrorJson(res, 400, "invalid_grant", "Invalid refresh token")
+            }
+            if (resource && !resourceMatches(resource, existing.resource)) {
+                return oauthErrorJson(res, 400, "invalid_target", "resource mismatch")
+            }
+
+            const tokens = await store.issueTokens({clientId: existing.clientId, userId: existing.userId, resource: existing.resource, scope: existing.scope})
+            logger.info("McpOAuth.token", `User ${existing.userId}`, `Client ${auth.client.id}`, "refresh_token")
+            res.json({access_token: tokens.accessToken, token_type: "Bearer", expires_in: tokens.expiresIn, refresh_token: tokens.refreshToken, scope: existing.scope})
+            return
+        }
+
+        oauthErrorJson(res, 400, "unsupported_grant_type", "Only authorization_code and refresh_token are supported")
+    } catch (ex) {
+        logger.error("McpOAuth.token", ex)
+        oauthErrorJson(res, 500, "server_error", "Token request failed")
+    }
+}
+
+/**
+ * Token revocation (RFC 7009).
+ */
+export const revoke = async (req: express.Request, res: express.Response): Promise<void> => {
+    setCorsHeaders(res)
+
+    try {
+        const auth = await authenticateClient(req)
+        if (!auth.client) {
+            return oauthErrorJson(res, 401, "invalid_client", "Client authentication failed")
+        }
+
+        const tokenValue = firstString(req.body?.token)
+        await store.revokeToken(tokenValue)
+        res.status(200).send()
+    } catch (ex) {
+        logger.error("McpOAuth.revoke", ex)
+        res.status(200).send()
+    }
+}

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -1,0 +1,148 @@
+// Strautomator MCP Streamable HTTP / JSON-RPC
+
+import {users, UserData} from "strautomator-core"
+import store from "./store"
+import {callTool, listTools} from "./tools"
+import {JsonRpcRequest, JsonRpcResponse} from "./types"
+import {getMcpConfig, setCorsHeaders, setWwwAuthenticate} from "./utils"
+import express = require("express")
+import logger from "anyhow"
+const packageVersion = require("../../package.json").version
+
+const jsonRpcError = (id: JsonRpcRequest["id"], code: number, message: string): JsonRpcResponse => {
+    return {jsonrpc: "2.0", id: id ?? null, error: {code, message}}
+}
+
+const authenticateRequest = async (req: express.Request, res: express.Response): Promise<UserData> => {
+    const header = req.headers.authorization || ""
+    const match = header.match(/^Bearer\s+(.+)$/i)
+    if (!match) {
+        setWwwAuthenticate(res)
+        res.status(401).json({error: "invalid_token", error_description: "Missing bearer token"})
+        return null
+    }
+
+    const token = await store.getAccessToken(match[1].trim())
+    const config = getMcpConfig()
+    if (!token || token.resource.replace(/\/+$/, "") != config.resource.replace(/\/+$/, "")) {
+        setWwwAuthenticate(res, 'error="invalid_token"')
+        res.status(401).json({error: "invalid_token", error_description: "Invalid or expired access token"})
+        return null
+    }
+
+    const user = await users.getById(token.userId)
+    if (!user) {
+        setWwwAuthenticate(res, 'error="invalid_token"')
+        res.status(401).json({error: "invalid_token", error_description: "User not found"})
+        return null
+    }
+    if (!user.isPro) {
+        res.status(403).json({error: "insufficient_scope", error_description: "The Strautomator MCP server is available to PRO members only"})
+        return null
+    }
+
+    return user
+}
+
+const handleRpc = async (user: UserData, message: JsonRpcRequest): Promise<JsonRpcResponse> => {
+    const id = message?.id ?? null
+    if (!message || message.jsonrpc != "2.0" || !message.method) {
+        return jsonRpcError(id, -32600, "Invalid Request")
+    }
+
+    const config = getMcpConfig()
+
+    if (message.method == "initialize") {
+        const requested = message.params?.protocolVersion
+        const protocolVersion = config.protocolVersions.includes(requested) ? requested : config.protocolVersions[0]
+        return {
+            jsonrpc: "2.0",
+            id,
+            result: {
+                protocolVersion,
+                capabilities: {tools: {listChanged: false}},
+                serverInfo: {name: "strautomator", title: "Strautomator", version: packageVersion},
+                instructions: "Strautomator MCP for PRO members. Tools operate on the authenticated athlete. Use get_automation_schema before creating or updating automations. Never ask the user for Strava tokens; authentication is already established."
+            }
+        }
+    }
+
+    if (message.method == "ping") {
+        return {jsonrpc: "2.0", id, result: {}}
+    }
+
+    if (message.method == "tools/list") {
+        return {jsonrpc: "2.0", id, result: {tools: listTools()}}
+    }
+
+    if (message.method == "tools/call") {
+        const name = message.params?.name
+        const args = message.params?.arguments || {}
+        if (!name) {
+            return jsonRpcError(id, -32602, "Missing tool name")
+        }
+        const result = await callTool(user, name, args)
+        return {jsonrpc: "2.0", id, result}
+    }
+
+    if (message.method == "notifications/initialized" || message.method.startsWith("notifications/")) {
+        return null
+    }
+
+    if (message.method == "resources/list") {
+        return {jsonrpc: "2.0", id, result: {resources: []}}
+    }
+    if (message.method == "prompts/list") {
+        return {jsonrpc: "2.0", id, result: {prompts: []}}
+    }
+
+    return jsonRpcError(id, -32601, `Method not found: ${message.method}`)
+}
+
+/**
+ * Handle MCP Streamable HTTP requests.
+ */
+export const handleMcp = async (req: express.Request, res: express.Response): Promise<void> => {
+    setCorsHeaders(res)
+
+    if (req.method == "OPTIONS") {
+        res.status(204).send()
+        return
+    }
+
+    if (req.method == "GET" || req.method == "DELETE") {
+        res.status(405).setHeader("Allow", "POST, OPTIONS").json({error: "method_not_allowed", error_description: "This MCP server is stateless and only accepts POST"})
+        return
+    }
+
+    const user = await authenticateRequest(req, res)
+    if (!user) {
+        return
+    }
+
+    try {
+        const body = req.body
+        const batch = Array.isArray(body)
+        const messages: JsonRpcRequest[] = batch ? body : [body]
+        const responses: JsonRpcResponse[] = []
+
+        for (const message of messages) {
+            const isNotification = message && message.id === undefined && typeof message.method == "string" && (message.method.startsWith("notifications/") || message.method == "initialized")
+            const response = await handleRpc(user, message)
+            if (response && !isNotification) {
+                responses.push(response)
+            }
+        }
+
+        if (responses.length == 0) {
+            res.status(202).send()
+            return
+        }
+
+        res.setHeader("Content-Type", "application/json")
+        res.json(batch ? responses : responses[0])
+    } catch (ex) {
+        logger.error("McpProtocol.handleMcp", user.id, ex)
+        res.status(500).json({jsonrpc: "2.0", id: null, error: {code: -32603, message: "Internal error"}})
+    }
+}

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -62,7 +62,7 @@ const handleRpc = async (user: UserData, message: JsonRpcRequest): Promise<JsonR
                 protocolVersion,
                 capabilities: {tools: {listChanged: false}},
                 serverInfo: {name: "strautomator", title: "Strautomator", version: packageVersion},
-                instructions: "Strautomator MCP for PRO members. Tools operate on the authenticated athlete. Use get_automation_schema before creating or updating automations. Never ask the user for Strava tokens; authentication is already established."
+                instructions: "Strautomator MCP for PRO members. Tools operate on the authenticated athlete and match the website API. Use get_automation_schema before creating or updating automations. Never ask the user for Strava tokens; authentication is already established."
             }
         }
     }

--- a/src/mcp/store.ts
+++ b/src/mcp/store.ts
@@ -1,0 +1,211 @@
+// Strautomator MCP persistence (Firestore)
+
+import {database} from "strautomator-core"
+import {McpAuthCode, McpAuthRequest, McpOAuthClient, McpToken} from "./types"
+import {getMcpConfig, hashToken, randomToken} from "./utils"
+import dayjs from "../dayjs"
+import logger from "anyhow"
+
+const COL_CLIENTS = "mcp-clients"
+const COL_REQUESTS = "mcp-auth-requests"
+const COL_CODES = "mcp-auth-codes"
+const COL_TOKENS = "mcp-tokens"
+
+const isExpired = (doc: {dateExpiry?: Date}): boolean => {
+    if (!doc?.dateExpiry) {
+        return true
+    }
+    return dayjs(doc.dateExpiry).isBefore(dayjs())
+}
+
+/**
+ * MCP OAuth store backed by Firestore.
+ */
+export class McpStore {
+    private constructor() {}
+    private static _instance: McpStore
+    static get Instance() {
+        return this._instance || (this._instance = new this())
+    }
+
+    // CLIENTS
+    // --------------------------------------------------------------------------
+
+    saveClient = async (client: McpOAuthClient): Promise<void> => {
+        await database.set(COL_CLIENTS, client, client.id)
+        logger.info("McpStore.saveClient", client.id, client.clientName || "unnamed", client.tokenEndpointAuthMethod)
+    }
+
+    getClient = async (clientId: string): Promise<McpOAuthClient> => {
+        if (!clientId) {
+            return null
+        }
+
+        const client: McpOAuthClient = await database.get(COL_CLIENTS, clientId)
+        if (!client) {
+            return null
+        }
+        if (isExpired(client)) {
+            await database.delete(COL_CLIENTS, clientId)
+            return null
+        }
+
+        return client
+    }
+
+    // AUTH REQUESTS
+    // --------------------------------------------------------------------------
+
+    saveAuthRequest = async (request: McpAuthRequest): Promise<void> => {
+        await database.set(COL_REQUESTS, request, request.id)
+    }
+
+    getAuthRequest = async (id: string): Promise<McpAuthRequest> => {
+        if (!id) {
+            return null
+        }
+
+        const request: McpAuthRequest = await database.get(COL_REQUESTS, id)
+        if (!request) {
+            return null
+        }
+        if (isExpired(request)) {
+            await database.delete(COL_REQUESTS, id)
+            return null
+        }
+
+        return request
+    }
+
+    deleteAuthRequest = async (id: string): Promise<void> => {
+        try {
+            await database.delete(COL_REQUESTS, id)
+        } catch (ex) {
+            logger.warn("McpStore.deleteAuthRequest", id, ex)
+        }
+    }
+
+    // AUTH CODES
+    // --------------------------------------------------------------------------
+
+    issueAuthCode = async (data: Omit<McpAuthCode, "id">): Promise<string> => {
+        const code = randomToken(32)
+        const doc: McpAuthCode = {id: hashToken(code), ...data}
+        await database.set(COL_CODES, doc, doc.id)
+        return code
+    }
+
+    consumeAuthCode = async (code: string): Promise<McpAuthCode> => {
+        if (!code) {
+            return null
+        }
+
+        const id = hashToken(code)
+        const doc: McpAuthCode = await database.get(COL_CODES, id)
+        await database.delete(COL_CODES, id)
+
+        if (!doc || isExpired(doc)) {
+            return null
+        }
+
+        return doc
+    }
+
+    // TOKENS
+    // --------------------------------------------------------------------------
+
+    issueTokens = async (data: {clientId: string; userId: string; resource: string; scope: string}): Promise<{accessToken: string; refreshToken: string; expiresIn: number}> => {
+        const config = getMcpConfig()
+        const accessToken = `mcp_at_${randomToken(32)}`
+        const refreshToken = `mcp_rt_${randomToken(32)}`
+        const accessId = hashToken(accessToken)
+        const refreshId = hashToken(refreshToken)
+        const now = dayjs()
+
+        const access: McpToken = {
+            id: accessId,
+            type: "access",
+            clientId: data.clientId,
+            userId: data.userId,
+            resource: data.resource,
+            scope: data.scope,
+            refreshId,
+            dateExpiry: now.add(config.accessTokenHours, "hours").toDate()
+        }
+        const refresh: McpToken = {
+            id: refreshId,
+            type: "refresh",
+            clientId: data.clientId,
+            userId: data.userId,
+            resource: data.resource,
+            scope: data.scope,
+            accessId,
+            dateExpiry: now.add(config.refreshTokenDays, "days").toDate()
+        }
+
+        await database.set(COL_TOKENS, access, access.id)
+        await database.set(COL_TOKENS, refresh, refresh.id)
+
+        return {accessToken, refreshToken, expiresIn: config.accessTokenHours * 3600}
+    }
+
+    getAccessToken = async (accessToken: string): Promise<McpToken> => {
+        if (!accessToken) {
+            return null
+        }
+
+        const doc: McpToken = await database.get(COL_TOKENS, hashToken(accessToken))
+        if (!doc || doc.type != "access" || isExpired(doc)) {
+            return null
+        }
+
+        return doc
+    }
+
+    consumeRefreshToken = async (refreshToken: string): Promise<McpToken> => {
+        if (!refreshToken) {
+            return null
+        }
+
+        const id = hashToken(refreshToken)
+        const doc: McpToken = await database.get(COL_TOKENS, id)
+        if (!doc || doc.type != "refresh" || isExpired(doc)) {
+            return null
+        }
+
+        await database.delete(COL_TOKENS, id)
+        if (doc.accessId) {
+            try {
+                await database.delete(COL_TOKENS, doc.accessId)
+            } catch (ex) {
+                logger.warn("McpStore.consumeRefreshToken", "Failed to delete previous access token", ex)
+            }
+        }
+
+        return doc
+    }
+
+    revokeToken = async (token: string): Promise<void> => {
+        if (!token) {
+            return
+        }
+
+        const id = hashToken(token)
+        const doc: McpToken = await database.get(COL_TOKENS, id)
+        if (!doc) {
+            return
+        }
+
+        await database.delete(COL_TOKENS, id)
+        const pairedId = doc.type == "access" ? doc.refreshId : doc.accessId
+        if (pairedId) {
+            try {
+                await database.delete(COL_TOKENS, pairedId)
+            } catch (ex) {
+                logger.warn("McpStore.revokeToken", "Failed to delete paired token", ex)
+            }
+        }
+    }
+}
+
+export default McpStore.Instance

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,13 +1,9 @@
-// Strautomator MCP tools (wrap existing core / API behaviour)
+// Strautomator MCP tools — thin wrappers around the same handlers used by the HTTP API.
 
-import {database, fitparser, gearwear, notifications, recipes, strava, subscriptions, users, UserData, RecipeData} from "strautomator-core"
-import {validateRecipeWebhookActions} from "../utils/urls"
-import {sanitizeActivity, sanitizeUser, toolError, toolResult} from "./utils"
-import dayjs from "../dayjs"
-import _ from "lodash"
+import {database, notifications, recipes, strava, users, UserData} from "strautomator-core"
+import {getGearwearById, getGearwearByUser, getProcessedActivities, getPublicUser, getRecipeStats, saveEstimatedFtp, upsertUserRecipe} from "../routes/logic"
+import {sanitizeUser, toolError, toolResult} from "./utils"
 import logger from "anyhow"
-const settings = require("setmeup").settings
-const packageVersion = require("../../package.json").version
 
 type ToolHandler = (user: UserData, args: any) => Promise<any>
 
@@ -18,77 +14,20 @@ interface ToolDef {
     handler: ToolHandler
 }
 
-const requireNumber = (value: any, label: string): number => {
-    const parsed = typeof value == "number" ? value : parseInt(value, 10)
-    if (!Number.isFinite(parsed)) {
-        throw new Error(`Invalid ${label}`)
-    }
-    return parsed
-}
-
 const tools: ToolDef[] = [
     {
         name: "get_account",
-        description: "Get the authenticated Strautomator user profile, preferences, subscription flags and linked accounts. Secrets and API tokens are omitted.",
-        inputSchema: {type: "object", properties: {}, additionalProperties: false},
-        handler: async (user) => {
-            const result = sanitizeUser(user)
-            if (user.subscriptionId) {
-                try {
-                    result.subscription = await subscriptions.getById(user.subscriptionId)
-                } catch (ex) {
-                    logger.warn("McpTools.get_account", user.id, "Failed to load subscription", ex)
-                }
-            }
-            return result
-        }
-    },
-    {
-        name: "list_recent_activities",
-        description: "List recent Strava activities for the authenticated user. Defaults to the last 10 activities from the past 21 days (max 50, lookback capped at 30 days).",
+        description: "Get the authenticated Strautomator user profile, preferences, automations and linked accounts. Secrets and API tokens are omitted.",
         inputSchema: {
             type: "object",
-            properties: {
-                limit: {type: "number", description: "Max activities to return (default 10, max 50)"},
-                since: {type: "number", description: "Unix timestamp to start from"}
-            },
+            properties: {refresh: {type: "boolean", description: "If true, refresh the Strava profile first (same as GET /api/users/:userId?refresh=1)"}},
             additionalProperties: false
         },
-        handler: async (user, args) => {
-            let limit = args.limit ? requireNumber(args.limit, "limit") : 10
-            if (limit > 50) limit = 50
-            if (limit < 1) limit = 1
-
-            let dateFrom = args.since ? dayjs.unix(requireNumber(args.since, "since")) : dayjs().subtract(21, "days")
-            const minDate = dayjs().subtract(30, "days")
-            if (dateFrom.isBefore(minDate)) dateFrom = minDate
-
-            let activities = await strava.activities.getActivities(user, {after: dateFrom})
-            activities.reverse()
-            if (activities.length > limit) {
-                activities = activities.slice(0, limit)
-            }
-            return activities.map(sanitizeActivity)
-        }
-    },
-    {
-        name: "get_activity",
-        description: "Get a single Strava activity by ID, including details used by automations.",
-        inputSchema: {
-            type: "object",
-            properties: {activityId: {type: "string", description: "Strava activity ID"}},
-            required: ["activityId"],
-            additionalProperties: false
-        },
-        handler: async (user, args) => {
-            if (!args.activityId) throw new Error("Missing activityId")
-            const activity = await strava.activities.getActivity(user, args.activityId.toString())
-            return sanitizeActivity(activity)
-        }
+        handler: async (user, args) => sanitizeUser(await getPublicUser(user, args.refresh === true))
     },
     {
         name: "list_processed_activities",
-        description: "List activities that Strautomator already processed (automation history).",
+        description: "List activities that Strautomator already processed (automation history). Same as GET /api/strava/:userId/processed-activities.",
         inputSchema: {
             type: "object",
             properties: {
@@ -98,49 +37,22 @@ const tools: ToolDef[] = [
             },
             additionalProperties: false
         },
-        handler: async (user, args) => {
-            const limit = args.limit ? requireNumber(args.limit, "limit") : null
-            const dateFrom = args.from ? dayjs(args.from.toString()).startOf("day").toDate() : null
-            const dateTo = args.to ? dayjs(args.to.toString()).endOf("day").toDate() : null
-            const activities = await strava.activityProcessing.getProcessedActivities(user, dateFrom, dateTo, limit)
-
-            if (user.garmin) {
-                await Promise.allSettled(
-                    activities.map(async (activity) => {
-                        const garminActivity = await fitparser.getMatchingActivity(user, activity, "garmin")
-                        if (garminActivity) activity.garminActivity = garminActivity
-                    })
-                )
-            }
-            if (user.wahoo) {
-                await Promise.allSettled(
-                    activities.map(async (activity) => {
-                        const wahooActivity = await fitparser.getMatchingActivity(user, activity, "wahoo")
-                        if (wahooActivity) activity.wahooActivity = wahooActivity
-                    })
-                )
-            }
-
-            return activities.map(sanitizeActivity)
-        }
+        handler: async (user, args) => getProcessedActivities(user, args)
     },
     {
         name: "get_processed_activity",
-        description: "Get a single Strautomator-processed activity, including which automations ran.",
+        description: "Get a single Strautomator-processed activity. Same as GET /api/strava/:userId/processed-activities/:id.",
         inputSchema: {
             type: "object",
             properties: {activityId: {type: "string", description: "Strava activity ID"}},
             required: ["activityId"],
             additionalProperties: false
         },
-        handler: async (user, args) => {
-            const activity = await strava.activityProcessing.getProcessedActivity(user, parseInt(args.activityId, 10))
-            return sanitizeActivity(activity)
-        }
+        handler: async (user, args) => strava.activityProcessing.getProcessedActivity(user, parseInt(args.activityId, 10))
     },
     {
         name: "process_activity",
-        description: "Run Strautomator automations on a specific Strava activity now (same as processing it from the website).",
+        description: "Run Strautomator automations on a specific Strava activity now. Same as GET /api/strava/:userId/process-activity/:activityId.",
         inputSchema: {
             type: "object",
             properties: {activityId: {type: "string", description: "Strava activity ID"}},
@@ -154,28 +66,22 @@ const tools: ToolDef[] = [
     },
     {
         name: "list_automations",
-        description: "List the user's Strautomator automations (recipes), including conditions and actions.",
+        description: "List the user's Strautomator automations (recipes).",
         inputSchema: {type: "object", properties: {}, additionalProperties: false},
         handler: async (user) => {
-            return Object.values(user.recipes || {})
+            const result = await getPublicUser(user)
+            return result.recipes || {}
         }
     },
     {
         name: "get_automation_schema",
-        description: "Return valid automation condition properties, operators and action types. Call this before save_automation.",
+        description: "Return valid automation condition properties, operators and action types from core. Call this before save_automation.",
         inputSchema: {type: "object", properties: {}, additionalProperties: false},
-        handler: async () => {
-            return {
-                operators: ["any", "=", "!=", "like", "notlike", "approx", ">", "<"],
-                logicalOperators: ["AND", "OR"],
-                properties: recipes.propertyList.map((p: any) => _.pick(p, ["value", "text", "type", "isPro"])),
-                actions: recipes.actionList.map((a: any) => _.pick(a, ["value", "text", "isPro"]))
-            }
-        }
+        handler: async () => ({properties: recipes.propertyList, actions: recipes.actionList})
     },
     {
         name: "save_automation",
-        description: "Create or update an automation. Omit id to create. Conditions and actions must follow get_automation_schema. Each condition needs property, operator and value. Each action needs type and value.",
+        description: "Create or update an automation. Same as POST /api/users/:userId/recipes. Omit id to create. Call get_automation_schema first.",
         inputSchema: {
             type: "object",
             properties: {
@@ -197,37 +103,12 @@ const tools: ToolDef[] = [
         },
         handler: async (user, args) => {
             const fresh = await users.getById(user.id)
-            const recipe: RecipeData = args as RecipeData
-
-            recipes.validate(fresh, recipe)
-            validateRecipeWebhookActions(recipe)
-
-            if (recipe.conditions?.length <= 2 && recipe.samePropertyOp) {
-                delete recipe.samePropertyOp
-            }
-
-            if (!recipe.id) {
-                recipe.id = recipes.generateId()
-                fresh.recipes = fresh.recipes || {}
-                fresh.recipes[recipe.id] = recipe
-            } else {
-                if (!fresh.recipes?.[recipe.id]) {
-                    throw new Error(`Automation ${recipe.id} not found`)
-                }
-                fresh.recipes[recipe.id] = recipe
-            }
-
-            if (fresh.suspended) {
-                fresh.suspended = false
-            }
-            fresh.recipeCount = Object.keys(fresh.recipes).length
-            await users.update(fresh, true)
-            return recipe
+            return upsertUserRecipe(fresh, args, "POST")
         }
     },
     {
         name: "delete_automation",
-        description: "Delete an automation by ID.",
+        description: "Delete an automation by ID. Same as DELETE /api/users/:userId/recipes/:recipeId.",
         inputSchema: {
             type: "object",
             properties: {id: {type: "string", description: "Automation ID"}},
@@ -236,96 +117,49 @@ const tools: ToolDef[] = [
         },
         handler: async (user, args) => {
             const fresh = await users.getById(user.id)
-            const recipeId = args.id.toString()
-            if (!fresh.recipes?.[recipeId]) {
-                throw new Error(`Automation ${recipeId} not found`)
-            }
-            delete fresh.recipes[recipeId]
-            fresh.recipeCount = Object.keys(fresh.recipes).length
-            await users.update(fresh, true)
-            return {deleted: true, id: recipeId}
+            return upsertUserRecipe(fresh, null, "DELETE", args.id.toString())
         }
     },
     {
         name: "get_automation_stats",
-        description: "Get execution stats for all automations, or a single automation if id is set.",
+        description: "Get execution stats for all automations, or a single automation if id is set. Same as GET /api/users/:userId/recipes/stats.",
         inputSchema: {
             type: "object",
             properties: {id: {type: "string", description: "Optional automation ID"}},
             additionalProperties: false
         },
-        handler: async (user, args) => {
-            if (args.id) {
-                if (!user.recipes?.[args.id]) {
-                    throw new Error(`Automation ${args.id} not found`)
-                }
-                return recipes.stats.getStats(user, user.recipes[args.id])
-            }
-            const arrStats = (await recipes.stats.getStats(user)) as any[]
-            arrStats.forEach((s) => delete s.activities)
-            return arrStats
-        }
+        handler: async (user, args) => getRecipeStats(user, args.id)
     },
     {
         name: "list_gearwear",
-        description: "List GearWear configurations for the user, including battery tracker when Garmin or Wahoo is linked.",
-        inputSchema: {type: "object", properties: {}, additionalProperties: false},
-        handler: async (user) => {
-            const result: any = {configs: await gearwear.getByUser(user)}
-            if (user.garmin?.id || user.wahoo?.id) {
-                const batteryTracker = await gearwear.getBatteryTracker(user)
-                if (batteryTracker) result.batteryTracker = batteryTracker
-            }
-            return result
-        }
+        description: "List GearWear configurations for the user. Same as GET /api/gearwear/:userId.",
+        inputSchema: {
+            type: "object",
+            properties: {refresh: {type: "boolean", description: "If true, refresh gear details from Strava in the background"}},
+            additionalProperties: false
+        },
+        handler: async (user, args) => getGearwearByUser(user, args.refresh === true)
     },
     {
         name: "get_gearwear",
-        description: "Get one GearWear configuration plus the Strava gear details.",
+        description: "Get one GearWear configuration plus the Strava gear details. Same as GET /api/gearwear/:userId/:gearId.",
         inputSchema: {
             type: "object",
             properties: {gearId: {type: "string", description: "Strava gear ID"}},
             required: ["gearId"],
             additionalProperties: false
         },
-        handler: async (user, args) => {
-            const config = await gearwear.getById(args.gearId.toString())
-            if (config && config.userId != user.id) {
-                throw new Error("No access to this GearWear configuration")
-            }
-            const gear = await strava.athletes.getGear(user, args.gearId.toString())
-            return {config, gear}
-        }
+        handler: async (user, args) => getGearwearById(user, args.gearId.toString())
     },
     {
         name: "list_athlete_records",
-        description: "Get the athlete's personal records tracked by Strautomator.",
+        description: "Get the athlete's personal records tracked by Strautomator. Same as GET /api/strava/:userId/athlete-records.",
         inputSchema: {type: "object", properties: {}, additionalProperties: false},
         handler: async (user) => strava.athletes.getAthleteRecords(user)
     },
     {
-        name: "list_routes",
-        description: "List the athlete's Strava routes.",
-        inputSchema: {type: "object", properties: {}, additionalProperties: false},
-        handler: async (user) => strava.routes.getUserRoutes(user)
-    },
-    {
-        name: "list_upcoming_club_events",
-        description: "List upcoming Strava club events. PRO accounts can look further ahead than the website default.",
-        inputSchema: {
-            type: "object",
-            properties: {days: {type: "number", description: "How many days ahead to look"}},
-            additionalProperties: false
-        },
-        handler: async (user, args) => {
-            const days = args.days ? requireNumber(args.days, "days") : settings.plans.pro.futureCalendarDays
-            const events = await strava.clubs.getUpcomingClubEvents(user, days, [user.profile.country])
-            return events
-        }
-    },
-    {
         name: "estimate_ftp",
-        description: "Estimate cycling FTP from recent activities with power. Does not write to Strava unless save is true.",
+        description: "Estimate cycling FTP from recent activities with power. Same as GET /api/strava/:userId/ftp/estimate. Set save=true to write it to Strava (POST).",
         inputSchema: {
             type: "object",
             properties: {
@@ -335,23 +169,15 @@ const tools: ToolDef[] = [
             additionalProperties: false
         },
         handler: async (user, args) => {
-            const estimation = await strava.performance.estimateFtp(user)
-            if (!estimation) {
-                return {estimated: false}
-            }
             if (args.save) {
-                if (args.ftp && args.ftp > 0) {
-                    estimation.ftpWatts = parseInt(args.ftp, 10)
-                }
-                const updated = await strava.performance.saveFtp(user, estimation)
-                return {saved: !!updated, ftp: estimation.ftpWatts, estimation}
+                return saveEstimatedFtp(user, args.ftp)
             }
-            return estimation
+            return (await strava.performance.estimateFtp(user)) || false
         }
     },
     {
         name: "list_notifications",
-        description: "List Strautomator notifications for the user.",
+        description: "List Strautomator notifications for the user. Same as GET /api/notifications/:userId/unread or /all.",
         inputSchema: {
             type: "object",
             properties: {includeRead: {type: "boolean", description: "If true, include already-read / expired notifications"}},
@@ -361,11 +187,11 @@ const tools: ToolDef[] = [
     },
     {
         name: "get_strava_status",
-        description: "Get the current Strava API / incident status tracked by Strautomator.",
+        description: "Get the current Strava API / incident status tracked by Strautomator. Same as GET /api/strava/status.",
         inputSchema: {type: "object", properties: {}, additionalProperties: false},
         handler: async () => {
             const stravaState = await database.appState.get("strava")
-            return {incident: stravaState?.incident || null, version: packageVersion}
+            return {incident: stravaState?.incident || null}
         }
     }
 ]

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,390 @@
+// Strautomator MCP tools (wrap existing core / API behaviour)
+
+import {database, fitparser, gearwear, notifications, recipes, strava, subscriptions, users, UserData, RecipeData} from "strautomator-core"
+import {validateRecipeWebhookActions} from "../utils/urls"
+import {sanitizeActivity, sanitizeUser, toolError, toolResult} from "./utils"
+import dayjs from "../dayjs"
+import _ from "lodash"
+import logger from "anyhow"
+const settings = require("setmeup").settings
+const packageVersion = require("../../package.json").version
+
+type ToolHandler = (user: UserData, args: any) => Promise<any>
+
+interface ToolDef {
+    name: string
+    description: string
+    inputSchema: any
+    handler: ToolHandler
+}
+
+const requireNumber = (value: any, label: string): number => {
+    const parsed = typeof value == "number" ? value : parseInt(value, 10)
+    if (!Number.isFinite(parsed)) {
+        throw new Error(`Invalid ${label}`)
+    }
+    return parsed
+}
+
+const tools: ToolDef[] = [
+    {
+        name: "get_account",
+        description: "Get the authenticated Strautomator user profile, preferences, subscription flags and linked accounts. Secrets and API tokens are omitted.",
+        inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        handler: async (user) => {
+            const result = sanitizeUser(user)
+            if (user.subscriptionId) {
+                try {
+                    result.subscription = await subscriptions.getById(user.subscriptionId)
+                } catch (ex) {
+                    logger.warn("McpTools.get_account", user.id, "Failed to load subscription", ex)
+                }
+            }
+            return result
+        }
+    },
+    {
+        name: "list_recent_activities",
+        description: "List recent Strava activities for the authenticated user. Defaults to the last 10 activities from the past 21 days (max 50, lookback capped at 30 days).",
+        inputSchema: {
+            type: "object",
+            properties: {
+                limit: {type: "number", description: "Max activities to return (default 10, max 50)"},
+                since: {type: "number", description: "Unix timestamp to start from"}
+            },
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            let limit = args.limit ? requireNumber(args.limit, "limit") : 10
+            if (limit > 50) limit = 50
+            if (limit < 1) limit = 1
+
+            let dateFrom = args.since ? dayjs.unix(requireNumber(args.since, "since")) : dayjs().subtract(21, "days")
+            const minDate = dayjs().subtract(30, "days")
+            if (dateFrom.isBefore(minDate)) dateFrom = minDate
+
+            let activities = await strava.activities.getActivities(user, {after: dateFrom})
+            activities.reverse()
+            if (activities.length > limit) {
+                activities = activities.slice(0, limit)
+            }
+            return activities.map(sanitizeActivity)
+        }
+    },
+    {
+        name: "get_activity",
+        description: "Get a single Strava activity by ID, including details used by automations.",
+        inputSchema: {
+            type: "object",
+            properties: {activityId: {type: "string", description: "Strava activity ID"}},
+            required: ["activityId"],
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            if (!args.activityId) throw new Error("Missing activityId")
+            const activity = await strava.activities.getActivity(user, args.activityId.toString())
+            return sanitizeActivity(activity)
+        }
+    },
+    {
+        name: "list_processed_activities",
+        description: "List activities that Strautomator already processed (automation history).",
+        inputSchema: {
+            type: "object",
+            properties: {
+                limit: {type: "number", description: "Max results"},
+                from: {type: "string", description: "Start date (ISO or YYYY-MM-DD)"},
+                to: {type: "string", description: "End date (ISO or YYYY-MM-DD)"}
+            },
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            const limit = args.limit ? requireNumber(args.limit, "limit") : null
+            const dateFrom = args.from ? dayjs(args.from.toString()).startOf("day").toDate() : null
+            const dateTo = args.to ? dayjs(args.to.toString()).endOf("day").toDate() : null
+            const activities = await strava.activityProcessing.getProcessedActivities(user, dateFrom, dateTo, limit)
+
+            if (user.garmin) {
+                await Promise.allSettled(
+                    activities.map(async (activity) => {
+                        const garminActivity = await fitparser.getMatchingActivity(user, activity, "garmin")
+                        if (garminActivity) activity.garminActivity = garminActivity
+                    })
+                )
+            }
+            if (user.wahoo) {
+                await Promise.allSettled(
+                    activities.map(async (activity) => {
+                        const wahooActivity = await fitparser.getMatchingActivity(user, activity, "wahoo")
+                        if (wahooActivity) activity.wahooActivity = wahooActivity
+                    })
+                )
+            }
+
+            return activities.map(sanitizeActivity)
+        }
+    },
+    {
+        name: "get_processed_activity",
+        description: "Get a single Strautomator-processed activity, including which automations ran.",
+        inputSchema: {
+            type: "object",
+            properties: {activityId: {type: "string", description: "Strava activity ID"}},
+            required: ["activityId"],
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            const activity = await strava.activityProcessing.getProcessedActivity(user, parseInt(args.activityId, 10))
+            return sanitizeActivity(activity)
+        }
+    },
+    {
+        name: "process_activity",
+        description: "Run Strautomator automations on a specific Strava activity now (same as processing it from the website).",
+        inputSchema: {
+            type: "object",
+            properties: {activityId: {type: "string", description: "Strava activity ID"}},
+            required: ["activityId"],
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            const processed = await strava.activityProcessing.processActivity(user, {id: parseInt(args.activityId, 10)})
+            return processed || {processed: false}
+        }
+    },
+    {
+        name: "list_automations",
+        description: "List the user's Strautomator automations (recipes), including conditions and actions.",
+        inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        handler: async (user) => {
+            return Object.values(user.recipes || {})
+        }
+    },
+    {
+        name: "get_automation_schema",
+        description: "Return valid automation condition properties, operators and action types. Call this before save_automation.",
+        inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        handler: async () => {
+            return {
+                operators: ["any", "=", "!=", "like", "notlike", "approx", ">", "<"],
+                logicalOperators: ["AND", "OR"],
+                properties: recipes.propertyList.map((p: any) => _.pick(p, ["value", "text", "type", "isPro"])),
+                actions: recipes.actionList.map((a: any) => _.pick(a, ["value", "text", "isPro"]))
+            }
+        }
+    },
+    {
+        name: "save_automation",
+        description: "Create or update an automation. Omit id to create. Conditions and actions must follow get_automation_schema. Each condition needs property, operator and value. Each action needs type and value.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                id: {type: "string", description: "Existing automation ID to update"},
+                title: {type: "string"},
+                conditions: {type: "array", items: {type: "object"}},
+                actions: {type: "array", items: {type: "object"}},
+                op: {type: "string", enum: ["AND", "OR"]},
+                samePropertyOp: {type: "string", enum: ["AND", "OR"]},
+                order: {type: "number"},
+                defaultFor: {type: "string", description: "Sport type this automation always applies to"},
+                killSwitch: {type: "boolean"},
+                disabled: {type: "boolean"},
+                counterProp: {type: "string"},
+                counterNoReset: {type: "boolean"}
+            },
+            required: ["title", "actions"],
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            const fresh = await users.getById(user.id)
+            const recipe: RecipeData = args as RecipeData
+
+            recipes.validate(fresh, recipe)
+            validateRecipeWebhookActions(recipe)
+
+            if (recipe.conditions?.length <= 2 && recipe.samePropertyOp) {
+                delete recipe.samePropertyOp
+            }
+
+            if (!recipe.id) {
+                recipe.id = recipes.generateId()
+                fresh.recipes = fresh.recipes || {}
+                fresh.recipes[recipe.id] = recipe
+            } else {
+                if (!fresh.recipes?.[recipe.id]) {
+                    throw new Error(`Automation ${recipe.id} not found`)
+                }
+                fresh.recipes[recipe.id] = recipe
+            }
+
+            if (fresh.suspended) {
+                fresh.suspended = false
+            }
+            fresh.recipeCount = Object.keys(fresh.recipes).length
+            await users.update(fresh, true)
+            return recipe
+        }
+    },
+    {
+        name: "delete_automation",
+        description: "Delete an automation by ID.",
+        inputSchema: {
+            type: "object",
+            properties: {id: {type: "string", description: "Automation ID"}},
+            required: ["id"],
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            const fresh = await users.getById(user.id)
+            const recipeId = args.id.toString()
+            if (!fresh.recipes?.[recipeId]) {
+                throw new Error(`Automation ${recipeId} not found`)
+            }
+            delete fresh.recipes[recipeId]
+            fresh.recipeCount = Object.keys(fresh.recipes).length
+            await users.update(fresh, true)
+            return {deleted: true, id: recipeId}
+        }
+    },
+    {
+        name: "get_automation_stats",
+        description: "Get execution stats for all automations, or a single automation if id is set.",
+        inputSchema: {
+            type: "object",
+            properties: {id: {type: "string", description: "Optional automation ID"}},
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            if (args.id) {
+                if (!user.recipes?.[args.id]) {
+                    throw new Error(`Automation ${args.id} not found`)
+                }
+                return recipes.stats.getStats(user, user.recipes[args.id])
+            }
+            const arrStats = (await recipes.stats.getStats(user)) as any[]
+            arrStats.forEach((s) => delete s.activities)
+            return arrStats
+        }
+    },
+    {
+        name: "list_gearwear",
+        description: "List GearWear configurations for the user, including battery tracker when Garmin or Wahoo is linked.",
+        inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        handler: async (user) => {
+            const result: any = {configs: await gearwear.getByUser(user)}
+            if (user.garmin?.id || user.wahoo?.id) {
+                const batteryTracker = await gearwear.getBatteryTracker(user)
+                if (batteryTracker) result.batteryTracker = batteryTracker
+            }
+            return result
+        }
+    },
+    {
+        name: "get_gearwear",
+        description: "Get one GearWear configuration plus the Strava gear details.",
+        inputSchema: {
+            type: "object",
+            properties: {gearId: {type: "string", description: "Strava gear ID"}},
+            required: ["gearId"],
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            const config = await gearwear.getById(args.gearId.toString())
+            if (config && config.userId != user.id) {
+                throw new Error("No access to this GearWear configuration")
+            }
+            const gear = await strava.athletes.getGear(user, args.gearId.toString())
+            return {config, gear}
+        }
+    },
+    {
+        name: "list_athlete_records",
+        description: "Get the athlete's personal records tracked by Strautomator.",
+        inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        handler: async (user) => strava.athletes.getAthleteRecords(user)
+    },
+    {
+        name: "list_routes",
+        description: "List the athlete's Strava routes.",
+        inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        handler: async (user) => strava.routes.getUserRoutes(user)
+    },
+    {
+        name: "list_upcoming_club_events",
+        description: "List upcoming Strava club events. PRO accounts can look further ahead than the website default.",
+        inputSchema: {
+            type: "object",
+            properties: {days: {type: "number", description: "How many days ahead to look"}},
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            const days = args.days ? requireNumber(args.days, "days") : settings.plans.pro.futureCalendarDays
+            const events = await strava.clubs.getUpcomingClubEvents(user, days, [user.profile.country])
+            return events
+        }
+    },
+    {
+        name: "estimate_ftp",
+        description: "Estimate cycling FTP from recent activities with power. Does not write to Strava unless save is true.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                save: {type: "boolean", description: "If true, save the estimated FTP to Strava"},
+                ftp: {type: "number", description: "Override watts to save when save=true"}
+            },
+            additionalProperties: false
+        },
+        handler: async (user, args) => {
+            const estimation = await strava.performance.estimateFtp(user)
+            if (!estimation) {
+                return {estimated: false}
+            }
+            if (args.save) {
+                if (args.ftp && args.ftp > 0) {
+                    estimation.ftpWatts = parseInt(args.ftp, 10)
+                }
+                const updated = await strava.performance.saveFtp(user, estimation)
+                return {saved: !!updated, ftp: estimation.ftpWatts, estimation}
+            }
+            return estimation
+        }
+    },
+    {
+        name: "list_notifications",
+        description: "List Strautomator notifications for the user.",
+        inputSchema: {
+            type: "object",
+            properties: {includeRead: {type: "boolean", description: "If true, include already-read / expired notifications"}},
+            additionalProperties: false
+        },
+        handler: async (user, args) => notifications.getByUser(user, args.includeRead === true)
+    },
+    {
+        name: "get_strava_status",
+        description: "Get the current Strava API / incident status tracked by Strautomator.",
+        inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        handler: async () => {
+            const stravaState = await database.appState.get("strava")
+            return {incident: stravaState?.incident || null, version: packageVersion}
+        }
+    }
+]
+
+export const listTools = () => {
+    return tools.map((t) => ({name: t.name, description: t.description, inputSchema: t.inputSchema}))
+}
+
+export const callTool = async (user: UserData, name: string, args: any) => {
+    const tool = tools.find((t) => t.name == name)
+    if (!tool) {
+        return toolError(`Unknown tool: ${name}`)
+    }
+
+    try {
+        const result = await tool.handler(user, args || {})
+        return toolResult(result)
+    } catch (ex) {
+        logger.error("McpTools.callTool", user.id, name, ex)
+        return toolError(ex.message || ex.toString())
+    }
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,0 +1,104 @@
+// Strautomator MCP types
+
+export interface McpOAuthClient {
+    /** Client ID (document ID). */
+    id: string
+    /** Optional display name. */
+    clientName?: string
+    /** SHA-256 hash of the client secret, if confidential. */
+    clientSecretHash?: string
+    /** Token endpoint auth method. */
+    tokenEndpointAuthMethod: "none" | "client_secret_post" | "client_secret_basic"
+    /** Registered redirect URIs. */
+    redirectUris: string[]
+    /** Allowed grant types. */
+    grantTypes: string[]
+    /** Allowed response types. */
+    responseTypes: string[]
+    /** Date the client was registered. */
+    dateIssued: Date
+    /** Date the client registration expires. */
+    dateExpiry: Date
+}
+
+export interface McpAuthRequest {
+    /** Request ID (document ID). */
+    id: string
+    /** OAuth client ID. */
+    clientId: string
+    /** Redirect URI for this authorization. */
+    redirectUri: string
+    /** Opaque state from the MCP client. */
+    state?: string
+    /** PKCE code challenge. */
+    codeChallenge: string
+    /** PKCE method, always S256. */
+    codeChallengeMethod: "S256"
+    /** Requested resource (MCP canonical URI). */
+    resource: string
+    /** Requested scope. */
+    scope: string
+    /** CSRF token for the consent form. */
+    consentToken: string
+    /** Date this pending request expires. */
+    dateExpiry: Date
+}
+
+export interface McpAuthCode {
+    /** SHA-256 of the authorization code (document ID). */
+    id: string
+    /** OAuth client ID. */
+    clientId: string
+    /** Strautomator user ID. */
+    userId: string
+    /** Redirect URI bound to this code. */
+    redirectUri: string
+    /** PKCE code challenge. */
+    codeChallenge: string
+    /** Resource (audience) bound to this code. */
+    resource: string
+    /** Granted scope. */
+    scope: string
+    /** Date this code expires. */
+    dateExpiry: Date
+}
+
+export interface McpToken {
+    /** SHA-256 of the token value (document ID). */
+    id: string
+    /** access or refresh. */
+    type: "access" | "refresh"
+    /** OAuth client ID. */
+    clientId: string
+    /** Strautomator user ID. */
+    userId: string
+    /** Resource (audience) bound to this token. */
+    resource: string
+    /** Granted scope. */
+    scope: string
+    /** Hash of the paired refresh token (access tokens only). */
+    refreshId?: string
+    /** Hash of the paired access token (refresh tokens only). */
+    accessId?: string
+    /** Date this token expires. */
+    dateExpiry: Date
+}
+
+export interface McpToolResult {
+    content: {type: "text"; text: string}[]
+    isError?: boolean
+}
+
+export interface JsonRpcRequest {
+    jsonrpc: "2.0"
+    id?: string | number | null
+    method: string
+    params?: any
+}
+
+export interface JsonRpcResponse {
+    jsonrpc: "2.0"
+    id: string | number | null
+    result?: any
+    error?: {code: number; message: string; data?: any}
+}

--- a/src/mcp/utils.spec.ts
+++ b/src/mcp/utils.spec.ts
@@ -1,0 +1,64 @@
+// Lightweight checks for MCP helpers (run with: npx tsx src/mcp/utils.spec.ts)
+
+import {createPkceChallenge, escapeHtml, firstString, hashToken, isValidRedirectUri, sanitizeUser, toBase64Url, verifyPkce} from "./utils"
+
+let failed = 0
+
+const assert = (cond: any, message: string) => {
+    if (!cond) {
+        failed++
+        console.error(`FAIL: ${message}`)
+    } else {
+        console.log(`ok: ${message}`)
+    }
+}
+
+const verifier = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
+assert(verifier.length == 66, "PKCE verifier length")
+const challenge = createPkceChallenge(verifier)
+assert(verifyPkce(verifier, challenge), "PKCE S256 round-trip")
+assert(!verifyPkce(verifier + "x", challenge), "PKCE rejects a modified verifier")
+assert(!verifyPkce("short", challenge), "PKCE rejects a short verifier")
+
+assert(hashToken("abc") == hashToken("abc"), "hashToken is stable")
+assert(hashToken("abc") != hashToken("abd"), "hashToken changes with input")
+assert(toBase64Url(Buffer.from("f")).indexOf("+") < 0, "base64url has no +")
+
+assert(isValidRedirectUri("https://example.com/callback"), "https redirect is valid")
+assert(isValidRedirectUri("http://127.0.0.1:1234/callback"), "loopback redirect is valid")
+assert(isValidRedirectUri("http://localhost:3000/auth"), "localhost redirect is valid")
+assert(isValidRedirectUri("cursor://anysphere.cursor-mcp/oauth/callback"), "custom scheme redirect is valid")
+assert(!isValidRedirectUri("http://evil.example/callback"), "public http redirect is rejected")
+assert(!isValidRedirectUri("javascript:alert(1)"), "javascript URI is rejected")
+assert(!isValidRedirectUri("https://user:pass@example.com/cb"), "userinfo is rejected")
+assert(!isValidRedirectUri("not a url"), "garbage URI is rejected")
+
+assert(escapeHtml('<script>"x"</script>') == "&lt;script&gt;&quot;x&quot;&lt;/script&gt;", "HTML is escaped")
+assert(firstString(["a", "b"]) == "a", "firstString unwraps arrays")
+assert(firstString(undefined) == "", "firstString handles missing values")
+
+const sanitized: any = sanitizeUser({
+    id: "1",
+    stravaTokens: {accessToken: "secret", refreshToken: "secret"},
+    urlToken: "calendar-secret",
+    confirmEmail: "abc:user@example.com",
+    garmin: {id: "g1", tokens: {accessToken: "g"}},
+    wahoo: {id: "w1", tokens: {accessToken: "w"}},
+    spotify: {id: "s1", tokens: {accessToken: "s"}},
+    paddleId: "p1"
+} as any)
+assert(!sanitized.stravaTokens, "Strava tokens are stripped")
+assert(!sanitized.urlToken, "Calendar URL token is stripped")
+assert(!sanitized.garmin.tokens, "Garmin tokens are stripped")
+assert(!sanitized.wahoo.tokens, "Wahoo tokens are stripped")
+assert(!sanitized.spotify.tokens, "Spotify tokens are stripped")
+assert(!sanitized.paddleId, "Paddle ID is stripped")
+assert(sanitized.confirmEmail == "user@example.com", "Email confirmation token is stripped")
+assert(sanitized.garmin.id == "g1", "Garmin profile id is kept")
+
+if (failed > 0) {
+    console.error(`${failed} assertion(s) failed`)
+    process.exit(1)
+}
+
+console.log("All MCP helper checks passed")

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -178,17 +178,6 @@ export const sanitizeUser = (user: UserData): any => {
 }
 
 /**
- * Remove heavy / unused fields from activities returned to MCP clients.
- */
-export const sanitizeActivity = (activity: any): any => {
-    if (!activity || typeof activity != "object") {
-        return activity
-    }
-
-    return _.omit(activity, ["polyline", "polylineSummary", "streams", "splits", "splitsMetric", "splitsStandard"])
-}
-
-/**
  * JSON-serialize a value, converting dates to ISO strings.
  */
 export const toJsonText = (data: any): string => {

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -1,0 +1,241 @@
+// Strautomator MCP helpers
+
+import crypto from "crypto"
+import _ from "lodash"
+import type {UserData} from "strautomator-core"
+
+/**
+ * MCP runtime config derived from SetMeUp settings.
+ */
+export const getMcpConfig = () => {
+    const settings = require("setmeup").settings
+    const mcp = settings.mcp || {}
+    const appUrl = (settings.app.url || "").replace(/\/+$/, "")
+
+    return {
+        appUrl,
+        issuer: appUrl,
+        resource: `${appUrl}/mcp`,
+        mcpPath: mcp.path || "/mcp",
+        scope: mcp.scope || "mcp",
+        accessTokenHours: mcp.accessTokenHours || 1,
+        refreshTokenDays: mcp.refreshTokenDays || 30,
+        authCodeMinutes: mcp.authCodeMinutes || 10,
+        authRequestMinutes: mcp.authRequestMinutes || 15,
+        clientDays: mcp.clientDays || 365,
+        cookieName: settings.cookie.sessionName,
+        cookieSecret: settings.cookie.secret,
+        protocolVersions: ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]
+    }
+}
+
+/**
+ * Encode a buffer as base64url (no padding).
+ */
+export const toBase64Url = (value: Buffer | string): string => {
+    const buf = Buffer.isBuffer(value) ? value : Buffer.from(value)
+    return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "")
+}
+
+/**
+ * Decode a base64url string.
+ */
+export const fromBase64Url = (value: string): Buffer => {
+    const padded = value.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((value.length + 3) % 4)
+    return Buffer.from(padded, "base64")
+}
+
+/**
+ * Cryptographically random URL-safe token.
+ */
+export const randomToken = (bytes: number = 32): string => {
+    return toBase64Url(crypto.randomBytes(bytes))
+}
+
+/**
+ * SHA-256 hex digest of a string.
+ */
+export const hashToken = (value: string): string => {
+    return crypto.createHash("sha256").update(value).digest("hex")
+}
+
+/**
+ * S256 PKCE challenge for the given verifier.
+ */
+export const createPkceChallenge = (verifier: string): string => {
+    return toBase64Url(crypto.createHash("sha256").update(verifier).digest())
+}
+
+/**
+ * Constant-time PKCE S256 verification.
+ */
+export const verifyPkce = (verifier: string, challenge: string): boolean => {
+    if (!verifier || !challenge) {
+        return false
+    }
+    if (verifier.length < 43 || verifier.length > 128) {
+        return false
+    }
+
+    const expected = createPkceChallenge(verifier)
+    const a = Buffer.from(expected)
+    const b = Buffer.from(challenge)
+    if (a.length != b.length) {
+        return false
+    }
+
+    return crypto.timingSafeEqual(a, b)
+}
+
+/**
+ * Whether a redirect URI is acceptable for dynamic client registration.
+ */
+export const isValidRedirectUri = (value: string): boolean => {
+    if (!value || typeof value != "string" || value.length > 2048) {
+        return false
+    }
+    if (/[\s\\]/.test(value) || value.includes(":///")) {
+        return false
+    }
+
+    let parsed: URL
+    try {
+        parsed = new URL(value)
+    } catch {
+        return false
+    }
+
+    if (parsed.username || parsed.password || parsed.hash) {
+        return false
+    }
+
+    const protocol = parsed.protocol.toLowerCase()
+    const host = parsed.hostname.toLowerCase()
+
+    if (protocol == "https:") {
+        return host.length > 0 && host != "localhost"
+    }
+
+    if (protocol == "http:") {
+        return host == "localhost" || host == "127.0.0.1" || host == "[::1]" || host == "::1"
+    }
+
+    if (/^[a-z][a-z0-9+.-]*:$/.test(protocol) && protocol != "javascript:" && protocol != "data:" && protocol != "file:") {
+        return host.length > 0 || parsed.pathname.length > 0
+    }
+
+    return false
+}
+
+/**
+ * Escape text for safe use in HTML.
+ */
+export const escapeHtml = (value: string): string => {
+    return (value || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#39;")
+}
+
+/**
+ * First string value from an Express query or body field.
+ */
+export const firstString = (value: any): string => {
+    if (Array.isArray(value)) {
+        value = value[0]
+    }
+    if (value === undefined || value === null) {
+        return ""
+    }
+    return String(value)
+}
+
+/**
+ * Strip secrets and credentials from a user object before returning it to an MCP client.
+ */
+export const sanitizeUser = (user: UserData): any => {
+    const result = _.cloneDeep(user) as any
+
+    delete result.stravaTokens
+    delete result.urlToken
+    delete result.garminAuthState
+    delete result.wahooAuthState
+    delete result.spotifyAuthState
+    delete result.paddleId
+    delete result.paddleTransactionId
+
+    if (result.confirmEmail) {
+        result.confirmEmail = result.confirmEmail.substring(result.confirmEmail.indexOf(":") + 1)
+    }
+    if (result.garmin) {
+        delete result.garmin.tokens
+    }
+    if (result.wahoo) {
+        delete result.wahoo.tokens
+    }
+    if (result.spotify) {
+        delete result.spotify.tokens
+    }
+
+    return result
+}
+
+/**
+ * Remove heavy / unused fields from activities returned to MCP clients.
+ */
+export const sanitizeActivity = (activity: any): any => {
+    if (!activity || typeof activity != "object") {
+        return activity
+    }
+
+    return _.omit(activity, ["polyline", "polylineSummary", "streams", "splits", "splitsMetric", "splitsStandard"])
+}
+
+/**
+ * JSON-serialize a value, converting dates to ISO strings.
+ */
+export const toJsonText = (data: any): string => {
+    return JSON.stringify(
+        data,
+        (_key, value) => {
+            if (value instanceof Date) {
+                return value.toISOString()
+            }
+            return value
+        },
+        2
+    )
+}
+
+/**
+ * MCP tool success payload.
+ */
+export const toolResult = (data: any) => {
+    return {content: [{type: "text" as const, text: typeof data == "string" ? data : toJsonText(data)}]}
+}
+
+/**
+ * MCP tool error payload.
+ */
+export const toolError = (message: string) => {
+    return {content: [{type: "text" as const, text: message}], isError: true}
+}
+
+/**
+ * Apply CORS headers required by browser-based MCP clients.
+ */
+export const setCorsHeaders = (res: any): void => {
+    res.setHeader("Access-Control-Allow-Origin", "*")
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
+    res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, MCP-Protocol-Version, MCP-Session-Id")
+    res.setHeader("Access-Control-Expose-Headers", "WWW-Authenticate, MCP-Protocol-Version, MCP-Session-Id")
+}
+
+/**
+ * RFC 9728 WWW-Authenticate challenge for the MCP resource.
+ */
+export const setWwwAuthenticate = (res: any, extra?: string): void => {
+    const config = getMcpConfig()
+    const parts = [`Bearer realm="Strautomator"`, `resource_metadata="${config.issuer}/.well-known/oauth-protected-resource"`, `scope="${config.scope}"`]
+    if (extra) {
+        parts.push(extra)
+    }
+    res.setHeader("WWW-Authenticate", parts.join(", "))
+}

--- a/src/routes/api/gearwear.ts
+++ b/src/routes/api/gearwear.ts
@@ -1,6 +1,7 @@
 // Strautomator API: GearWear
 
-import {logHelper, gearwear, GearWearConfig, strava, UserData} from "strautomator-core"
+import {logHelper, gearwear, GearWearConfig, UserData} from "strautomator-core"
+import {getGearwearById, getGearwearByUser} from "../logic"
 import auth from "../auth"
 import _ from "lodash"
 import express = require("express")
@@ -21,24 +22,7 @@ router.get("/:userId", async (req: express.Request, res: express.Response) => {
         const user: UserData = (await auth.requestValidator(req, res)) as UserData
         if (!user) return
 
-        const result: any = {}
-        const gearwearConfigs = await gearwear.getByUser(user)
-        result.configs = gearwearConfigs
-
-        // Also get battery tracker for PRO users.
-        if (user.isPro && (user.garmin?.id || user.wahoo?.id)) {
-            const batteryTracker = await gearwear.getBatteryTracker(user)
-            if (batteryTracker) {
-                result.batteryTracker = batteryTracker
-            }
-        }
-
-        // If a refresh query was passed, trigger an async call to
-        // refresh gear details from Strava.
-        if (req.query?.refresh) {
-            gearwear.refreshGearDetails(user)
-        }
-
+        const result = await getGearwearByUser(user, !!req.query?.refresh)
         webserver.renderJson(req, res, result)
     } catch (ex) {
         webserver.renderError(req, res, ex)
@@ -56,18 +40,10 @@ router.get("/:userId/:gearId", async (req: express.Request, res: express.Respons
         const user: UserData = (await auth.requestValidator(req, res)) as UserData
         if (!user) return
 
-        // Get GearWear config and gear details from Strava.
-        const config = await gearwear.getById(gearId as string)
-        const gear = await strava.athletes.getGear(user, gearId as string)
-
-        // Stop here if owner of the specified gear is not the logged user.
-        if (config && config.userId != user.id) {
-            return webserver.renderError(req, res, `${logHelper.user(user)} has no access to GearWear ${gearId}`, 403)
-        }
-
-        webserver.renderJson(req, res, {config: config, gear: gear})
+        const result = await getGearwearById(user, gearId as string)
+        webserver.renderJson(req, res, result)
     } catch (ex) {
-        webserver.renderError(req, res, ex)
+        webserver.renderError(req, res, ex, ex.status)
     }
 })
 

--- a/src/routes/api/strava.ts
+++ b/src/routes/api/strava.ts
@@ -1,6 +1,7 @@
 // Strautomator API: Strava
 
-import {database, events, fitparser, maps, strava, users, UserData, StravaAthleteRecords, StravaSport, StravaActivityFilter, StravaProcessedActivity} from "strautomator-core"
+import {database, events, fitparser, maps, strava, users, UserData, StravaAthleteRecords, StravaSport, StravaActivityFilter} from "strautomator-core"
+import {getProcessedActivities, saveEstimatedFtp} from "../logic"
 import auth from "../auth"
 import dayjs from "../../dayjs"
 import _ from "lodash"
@@ -148,33 +149,7 @@ router.get("/:userId/processed-activities", async (req: express.Request, res: ex
         const user: UserData = (await auth.requestValidator(req, res)) as UserData
         if (!user) return
 
-        // Limit number of activities returned?
-        const limit: number = req.query.limit ? parseInt(req.query.limit as string) : null
-        const dateFrom: Date = req.query.from ? dayjs(req.query.from.toString()).startOf("day").toDate() : null
-        const dateTo: Date = req.query.to ? dayjs(req.query.to.toString()).endOf("day").toDate() : null
-
-        const activities = await strava.activityProcessing.getProcessedActivities(user, dateFrom, dateTo, limit)
-
-        // If user has a Garmin or Wahoo account linked, append the related FIT file activities as well.
-        if (user.garmin) {
-            const getGarminActivity = async (activity: StravaProcessedActivity) => {
-                const garminActivity = await fitparser.getMatchingActivity(user, activity, "garmin")
-                if (garminActivity) {
-                    activity.garminActivity = garminActivity
-                }
-            }
-            await Promise.allSettled(activities.map(getGarminActivity))
-        }
-        if (user.wahoo) {
-            const getWahooActivity = async (activity: StravaProcessedActivity) => {
-                const garminActivity = await fitparser.getMatchingActivity(user, activity, "wahoo")
-                if (garminActivity) {
-                    activity.wahooActivity = garminActivity
-                }
-            }
-            await Promise.allSettled(activities.map(getWahooActivity))
-        }
-
+        const activities = await getProcessedActivities(user, req.query)
         webserver.renderJson(req, res, activities)
     } catch (ex) {
         webserver.renderError(req, res, ex)
@@ -385,14 +360,7 @@ router.post("/:userId/ftp/estimate", async (req: express.Request, res: express.R
         const user: UserData = (await auth.requestValidator(req, res)) as UserData
         if (!user) return
 
-        const estimation = await strava.performance.estimateFtp(user)
-        if (req.body?.ftp && req.body.ftp > 0) {
-            estimation.ftpWatts = parseInt(req.body.ftp)
-        }
-
-        // Update the user's FTP.
-        const updated = await strava.performance.saveFtp(user, estimation)
-        const result = updated ? {ftp: estimation.ftpWatts} : false
+        const result = await saveEstimatedFtp(user, req.body?.ftp)
         webserver.renderJson(req, res, result)
     } catch (ex) {
         webserver.renderError(req, res, ex)

--- a/src/routes/api/users.ts
+++ b/src/routes/api/users.ts
@@ -1,8 +1,8 @@
 // Strautomator API: Users
 
-import {logHelper, gdpr, mailer, paddle, paypal, recipes, subscriptions, strava, users, RecipeData, RecipeStatsData, UserData, UserPreferences} from "strautomator-core"
+import {logHelper, gdpr, mailer, paddle, paypal, recipes, subscriptions, strava, users, UserData, UserPreferences} from "strautomator-core"
 import {FieldValue} from "@google-cloud/firestore"
-import {validateRecipeWebhookActions} from "../../utils/urls"
+import {getPublicUser, getRecipeStats, upsertUserRecipe} from "../logic"
 import auth from "../auth"
 import dayjs from "../../dayjs"
 import _ from "lodash"
@@ -22,62 +22,10 @@ router.get("/:userId", async (req: express.Request, res: express.Response) => {
     try {
         if (!req.params) throw new Error("Missing request params")
 
-        const userId = req.params.userId as string
         const user: UserData = (await auth.requestValidator(req, res)) as UserData
         if (!user) return
 
-        // DEPRECATED! Recipes with no order must have a default set now.
-        let recipeCounter = 0
-        for (let recipe of Object.values(user.recipes)) {
-            if (!recipe.order) {
-                recipe.order = recipeCounter
-                recipeCounter++
-            }
-        }
-
-        // Refresh profile from Strava?
-        if (req.query?.refresh) {
-            const profile = await strava.athletes.getAthlete(user.stravaTokens)
-
-            // Merge bikes and shoes.
-            // Do not overwrite all gear details, as they won't have brand and model (coming from the athlete endpoint).
-            // Merge the bikes and shoes instead.
-            for (let bike of profile.bikes) {
-                const existingBike = _.find(user.profile.bikes, {id: bike.id})
-                if (existingBike) _.defaults(bike, existingBike)
-            }
-            for (let shoes of profile.shoes) {
-                const existingShoes = _.find(user.profile.shoes, {id: shoes.id})
-                if (existingShoes) _.defaults(shoes, existingShoes)
-            }
-
-            // Save updated profile on the database.
-            const data: Partial<UserData> = {
-                id: userId,
-                profile: profile,
-                displayName: user.preferences.privacyMode ? user.displayName : profile.username || profile.firstName || profile.lastName
-            }
-            users.update(data)
-
-            // Update profile on current user.
-            user.profile = profile
-        }
-
-        // Clone user object and remove sensitive data.
-        const result = _.cloneDeep(user)
-        if (result.confirmEmail) {
-            result.confirmEmail = result.confirmEmail.substring(result.confirmEmail.indexOf(":") + 1)
-        }
-        if (result.garmin) {
-            delete result.garmin.tokens
-        }
-        if (result.wahoo) {
-            delete result.wahoo.tokens
-        }
-        if (result.spotify) {
-            delete result.spotify.tokens
-        }
-
+        const result = await getPublicUser(user, !!req.query?.refresh)
         webserver.renderJson(req, res, result)
     } catch (ex) {
         webserver.renderError(req, res, ex)
@@ -455,85 +403,10 @@ const routeUserRecipe = async (req: any, res: any) => {
             return webserver.renderError(req, res, `User ${userId} not found`, 404)
         }
 
-        // Get and validate the recipe data.
-        const recipeId: string = req.params.recipeId || req.body?.id
-        const recipe: RecipeData = req.body?.title ? req.body : user.recipes[recipeId]
-        if (!recipe) {
-            return webserver.renderError(req, res, `Recipe ${recipeId} not found`, 404)
-        }
-
-        const asJson = recipe ? recipe["asJson"] || false : false
-        if (asJson) {
-            delete recipe["asJson"]
-        }
-
-        // Make sure recipe was sent in the correct format.
-        if (req.method != "DELETE") {
-            try {
-                recipes.validate(user, recipe)
-                validateRecipeWebhookActions(recipe)
-            } catch (ex) {
-                if (asJson && ex.message) {
-                    ex.message += " (recipe edited as JSON)"
-                }
-
-                return webserver.renderError(req, res, ex, 400)
-            }
-        }
-
-        // If 2 conditions or less, we don't need to set a value for samePropertyOp, as we only use the default op.
-        if (recipe.conditions?.length <= 2 && recipe.samePropertyOp) {
-            delete recipe.samePropertyOp
-        }
-
-        const operatorLog = !recipe.samePropertyOp || recipe.op == recipe.samePropertyOp ? recipe.op : `${recipe.samePropertyOp} ${recipe.op}`
-
-        // Creating a new recipe?
-        if (!recipe.id && req.method == "POST") {
-            if (!user.isPro && user.recipeCount >= settings.plans.free.maxRecipes) {
-                return webserver.renderError(req, res, `Maximum of ${settings.plans.free.maxRecipes} automations allowed on the free plan`, 402)
-            }
-
-            recipe.id = recipes.generateId()
-
-            // Add to user's recipe list.
-            user.recipes[recipe.id] = recipe
-            logger.info("Routes.users", logHelper.user(user), `New recipe ${recipe.id}: ${recipe.title}`, operatorLog, `${recipe.conditions.length} conditions, ${recipe.actions.length} actions`)
-        } else {
-            const existingRecipe = user.recipes[recipeId]
-
-            // Recipe not found?
-            if (!existingRecipe) {
-                return webserver.renderError(req, res, `Recipe ${recipeId} not found`, 404)
-            }
-
-            // Updating an existing recipe?
-            if (req.method == "POST") {
-                user.recipes[recipe.id] = recipe
-                logger.info("Routes.users", logHelper.user(user), `Updated recipe ${recipe.id}: ${recipe.title}`, operatorLog, `${recipe.conditions.length} conditions, ${recipe.actions.length} actions`)
-            }
-            // Deleting a recipe?
-            else if (req.method == "DELETE") {
-                delete user.recipes[recipeId]
-                logger.info("Routes.users", logHelper.user(user), `Deleted recipe ${recipeId}: ${recipe.title}`)
-            }
-            // Invalid call.
-            else {
-                return webserver.renderError(req, res, `Invalid method for recipe ${recipeId}`, 405)
-            }
-        }
-
-        // User was recently suspended? Unset the flag.
-        if (user.suspended) {
-            user.suspended = false
-        }
-
-        // Update recipe count on user data.
-        user.recipeCount = Object.keys(user.recipes).length
-        await users.update(user, true)
+        const recipe = await upsertUserRecipe(user, req.body, req.method, req.params.recipeId)
         webserver.renderJson(req, res, recipe)
     } catch (ex) {
-        webserver.renderError(req, res, ex)
+        webserver.renderError(req, res, ex, ex.status)
     }
 }
 
@@ -576,11 +449,7 @@ router.get("/:userId/recipes/stats", async (req: express.Request, res: express.R
         const user: UserData = (await auth.requestValidator(req, res)) as UserData
         if (!user) return
 
-        const arrStats = (await recipes.stats.getStats(user)) as RecipeStatsData[]
-
-        // We don't need full list of activity IDs sent to the client.
-        arrStats.forEach((s) => delete s.activities)
-        webserver.renderJson(req, res, arrStats)
+        webserver.renderJson(req, res, await getRecipeStats(user))
     } catch (ex) {
         webserver.renderError(req, res, ex)
     }
@@ -597,12 +466,7 @@ router.get("/:userId/recipes/stats/:recipeId", async (req: express.Request, res:
         const user: UserData = (await auth.requestValidator(req, res)) as UserData
         if (!user) return
 
-        if (!user.recipes[recipeId]) {
-            throw new Error(`Invalid recipe: ${recipeId}`)
-        }
-
-        const stats = (await recipes.stats.getStats(user, user.recipes[recipeId])) as RecipeStatsData
-        webserver.renderJson(req, res, stats)
+        webserver.renderJson(req, res, await getRecipeStats(user, recipeId))
     } catch (ex) {
         webserver.renderError(req, res, ex)
     }

--- a/src/routes/logic.ts
+++ b/src/routes/logic.ts
@@ -1,0 +1,222 @@
+// Shared handlers used by the HTTP API and the MCP tools.
+
+import {fitparser, gearwear, logHelper, recipes, strava, users, RecipeData, RecipeStatsData, StravaProcessedActivity, UserData} from "strautomator-core"
+import {validateRecipeWebhookActions} from "../utils/urls"
+import dayjs from "../dayjs"
+import _ from "lodash"
+import logger from "anyhow"
+const settings = require("setmeup").settings
+
+/**
+ * Public user payload returned by GET /api/users/:userId.
+ */
+export const getPublicUser = async (user: UserData, refresh?: boolean): Promise<any> => {
+    let recipeCounter = 0
+    for (let recipe of Object.values(user.recipes)) {
+        if (!recipe.order) {
+            recipe.order = recipeCounter
+            recipeCounter++
+        }
+    }
+
+    if (refresh) {
+        const profile = await strava.athletes.getAthlete(user.stravaTokens)
+
+        for (let bike of profile.bikes) {
+            const existingBike = _.find(user.profile.bikes, {id: bike.id})
+            if (existingBike) _.defaults(bike, existingBike)
+        }
+        for (let shoes of profile.shoes) {
+            const existingShoes = _.find(user.profile.shoes, {id: shoes.id})
+            if (existingShoes) _.defaults(shoes, existingShoes)
+        }
+
+        const data: Partial<UserData> = {
+            id: user.id,
+            profile: profile,
+            displayName: user.preferences.privacyMode ? user.displayName : profile.username || profile.firstName || profile.lastName
+        }
+        users.update(data)
+        user.profile = profile
+    }
+
+    const result = _.cloneDeep(user)
+    if (result.confirmEmail) {
+        result.confirmEmail = result.confirmEmail.substring(result.confirmEmail.indexOf(":") + 1)
+    }
+    if (result.garmin) {
+        delete result.garmin.tokens
+    }
+    if (result.wahoo) {
+        delete result.wahoo.tokens
+    }
+    if (result.spotify) {
+        delete result.spotify.tokens
+    }
+
+    return result
+}
+
+/**
+ * Create, update or delete a user automation (same as POST/DELETE /api/users/:userId/recipes).
+ */
+export const upsertUserRecipe = async (user: UserData, recipeInput: any, method: string, recipeId?: string): Promise<RecipeData> => {
+    const id: string = recipeId || recipeInput?.id
+    const recipe: RecipeData = recipeInput?.title ? recipeInput : user.recipes[id]
+    if (!recipe) {
+        throw Object.assign(new Error(`Recipe ${id} not found`), {status: 404})
+    }
+
+    const asJson = recipe ? recipe["asJson"] || false : false
+    if (asJson) {
+        delete recipe["asJson"]
+    }
+
+    if (method != "DELETE") {
+        try {
+            recipes.validate(user, recipe)
+            validateRecipeWebhookActions(recipe)
+        } catch (ex) {
+            if (asJson && ex.message) {
+                ex.message += " (recipe edited as JSON)"
+            }
+            ex.status = 400
+            throw ex
+        }
+    }
+
+    if (recipe.conditions?.length <= 2 && recipe.samePropertyOp) {
+        delete recipe.samePropertyOp
+    }
+
+    const operatorLog = !recipe.samePropertyOp || recipe.op == recipe.samePropertyOp ? recipe.op : `${recipe.samePropertyOp} ${recipe.op}`
+
+    if (!recipe.id && method == "POST") {
+        if (!user.isPro && user.recipeCount >= settings.plans.free.maxRecipes) {
+            throw Object.assign(new Error(`Maximum of ${settings.plans.free.maxRecipes} automations allowed on the free plan`), {status: 402})
+        }
+
+        recipe.id = recipes.generateId()
+        user.recipes[recipe.id] = recipe
+        logger.info("Routes.users", logHelper.user(user), `New recipe ${recipe.id}: ${recipe.title}`, operatorLog, `${recipe.conditions.length} conditions, ${recipe.actions.length} actions`)
+    } else {
+        const existingRecipe = user.recipes[id]
+        if (!existingRecipe) {
+            throw Object.assign(new Error(`Recipe ${id} not found`), {status: 404})
+        }
+
+        if (method == "POST") {
+            user.recipes[recipe.id] = recipe
+            logger.info("Routes.users", logHelper.user(user), `Updated recipe ${recipe.id}: ${recipe.title}`, operatorLog, `${recipe.conditions.length} conditions, ${recipe.actions.length} actions`)
+        } else if (method == "DELETE") {
+            delete user.recipes[id]
+            logger.info("Routes.users", logHelper.user(user), `Deleted recipe ${recipeId || id}: ${recipe.title}`)
+        } else {
+            throw Object.assign(new Error(`Invalid method for recipe ${id}`), {status: 405})
+        }
+    }
+
+    if (user.suspended) {
+        user.suspended = false
+    }
+
+    user.recipeCount = Object.keys(user.recipes).length
+    await users.update(user, true)
+    return recipe
+}
+
+/**
+ * Automation stats returned by GET /api/users/:userId/recipes/stats[/:recipeId].
+ */
+export const getRecipeStats = async (user: UserData, recipeId?: string): Promise<RecipeStatsData | RecipeStatsData[]> => {
+    if (recipeId) {
+        if (!user.recipes[recipeId]) {
+            throw new Error(`Invalid recipe: ${recipeId}`)
+        }
+        return (await recipes.stats.getStats(user, user.recipes[recipeId])) as RecipeStatsData
+    }
+
+    const arrStats = (await recipes.stats.getStats(user)) as RecipeStatsData[]
+    arrStats.forEach((s) => delete s.activities)
+    return arrStats
+}
+
+/**
+ * Processed activities returned by GET /api/strava/:userId/processed-activities.
+ */
+export const getProcessedActivities = async (user: UserData, query?: {limit?: any; from?: any; to?: any}): Promise<StravaProcessedActivity[]> => {
+    const limit: number = query?.limit ? parseInt(query.limit as string) : null
+    const dateFrom: Date = query?.from ? dayjs(query.from.toString()).startOf("day").toDate() : null
+    const dateTo: Date = query?.to ? dayjs(query.to.toString()).endOf("day").toDate() : null
+
+    const activities = await strava.activityProcessing.getProcessedActivities(user, dateFrom, dateTo, limit)
+
+    if (user.garmin) {
+        const getGarminActivity = async (activity: StravaProcessedActivity) => {
+            const garminActivity = await fitparser.getMatchingActivity(user, activity, "garmin")
+            if (garminActivity) {
+                activity.garminActivity = garminActivity
+            }
+        }
+        await Promise.allSettled(activities.map(getGarminActivity))
+    }
+    if (user.wahoo) {
+        const getWahooActivity = async (activity: StravaProcessedActivity) => {
+            const wahooActivity = await fitparser.getMatchingActivity(user, activity, "wahoo")
+            if (wahooActivity) {
+                activity.wahooActivity = wahooActivity
+            }
+        }
+        await Promise.allSettled(activities.map(getWahooActivity))
+    }
+
+    return activities
+}
+
+/**
+ * Save estimated FTP, same as POST /api/strava/:userId/ftp/estimate.
+ */
+export const saveEstimatedFtp = async (user: UserData, ftp?: number): Promise<any> => {
+    const estimation = await strava.performance.estimateFtp(user)
+    if (ftp && ftp > 0) {
+        estimation.ftpWatts = parseInt(ftp as any)
+    }
+
+    const updated = await strava.performance.saveFtp(user, estimation)
+    return updated ? {ftp: estimation.ftpWatts} : false
+}
+
+/**
+ * GearWear list returned by GET /api/gearwear/:userId.
+ */
+export const getGearwearByUser = async (user: UserData, refresh?: boolean): Promise<any> => {
+    const result: any = {}
+    result.configs = await gearwear.getByUser(user)
+
+    if (user.isPro && (user.garmin?.id || user.wahoo?.id)) {
+        const batteryTracker = await gearwear.getBatteryTracker(user)
+        if (batteryTracker) {
+            result.batteryTracker = batteryTracker
+        }
+    }
+
+    if (refresh) {
+        gearwear.refreshGearDetails(user)
+    }
+
+    return result
+}
+
+/**
+ * Single GearWear payload returned by GET /api/gearwear/:userId/:gearId.
+ */
+export const getGearwearById = async (user: UserData, gearId: string): Promise<any> => {
+    const config = await gearwear.getById(gearId)
+    const gear = await strava.athletes.getGear(user, gearId)
+
+    if (config && config.userId != user.id) {
+        throw Object.assign(new Error(`${logHelper.user(user)} has no access to GearWear ${gearId}`), {status: 403})
+    }
+
+    return {config: config, gear: gear}
+}

--- a/src/webserver.ts
+++ b/src/webserver.ts
@@ -90,7 +90,12 @@ class WebServer {
                 } else if (req.originalUrl.substring(0, 14) == "/api/fitupload") {
                     next()
                 } else {
-                    bodyParser.json()(req, res, next)
+                    bodyParser.json()(req, res, (jsonErr) => {
+                        if (jsonErr) {
+                            return next(jsonErr)
+                        }
+                        bodyParser.urlencoded({extended: false})(req, res, next)
+                    })
                 }
             })
             this.app.use((err: Error, req: express.Request, res: express.Response, next) => {
@@ -119,6 +124,8 @@ class WebServer {
 
                 const rateLimit = require("express-rate-limit")(settings.api.rateLimit)
                 this.app.use("/api/*catchall", rateLimit)
+                this.app.use("/mcp", rateLimit)
+                this.app.use("/mcp/*catchall", rateLimit)
                 this.app.use("/api/*catchall", (req, res, next) => {
                     const reqRateLimit = (req as any).rateLimit
                     const statusCode = res.statusCode || "not sent"
@@ -157,6 +164,10 @@ class WebServer {
                     this.app.use(`/api/${basename}`, require(`./routes/api/${r}`))
                 }
             }
+
+            // MCP server (OAuth + Streamable HTTP). Must be registered before the Nuxt renderer.
+            const mcp = require("./mcp")
+            mcp.setup(this.app)
 
             // Setup affiliate links.
             if (settings.affiliates.server.url) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hosts a remote MCP server at `/mcp` for PRO members. MCP clients authenticate with OAuth 2.1; users still sign in with Strava. The MCP layer issues its own audience-bound tokens and never accepts or forwards Strava access tokens.

## OAuth 2.1 (spec)

- Protected resource metadata (RFC 9728) at `/.well-known/oauth-protected-resource`
- Authorization server metadata (RFC 8414) at `/.well-known/oauth-authorization-server`
- Dynamic client registration (RFC 7591) at `/mcp/oauth/register`
- Authorization code + PKCE S256 at `/mcp/oauth/authorize` and `/mcp/oauth/token`
- Token revocation (RFC 7009)
- Resource indicators (RFC 8707): tokens are bound to `https://<host>/mcp`

Login reuses the existing `/auth/login` Strava flow. Non-PRO users get a billing page instead of a code.

## MCP tools

Streamable HTTP JSON-RPC at `POST /mcp`. Tools call the same handlers as the website API (`src/routes/logic.ts`):

- Account, processed-activity history, process activity
- Automations (list / full schema / save / delete / stats)
- GearWear, records, FTP, notifications, Strava status

Raw Strava activity, club, and calendar tools are not included. `get_automation_schema` returns the full core property and action lists (MCP is PRO-only).

## How to connect

Use server URL `https://strautomator.com/mcp` (also shown on the Account page for PRO users). The client will register itself, open a browser for Strava login + consent, then call tools with the issued bearer token.

Companion settings: https://github.com/strautomator/core/pull/85
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5773b352-0fa5-43ae-b360-4eef19071fde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5773b352-0fa5-43ae-b360-4eef19071fde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

