### PR TITLE
Fix MCP OAuth consent refresh and token housekeeping

### DIFF
--- a/src/mcp/html.ts
+++ b/src/mcp/html.ts
@@ -2,6 +2,9 @@
 
 import {escapeHtml, getMcpConfig} from "./utils"
 
+/**
+ * Shared HTML layout for OAuth consent and error pages.
+ */
 const layout = (title: string, body: string): string => {
     const config = getMcpConfig()
     return `<!DOCTYPE html>
@@ -38,6 +41,9 @@ const layout = (title: string, body: string): string => {
 </html>`
 }
 
+/**
+ * OAuth consent page shown to logged-in PRO users before issuing an authorization code.
+ */
 export const consentPage = (options: {clientName: string; userName: string; requestId: string; consentToken: string}): string => {
     const clientName = escapeHtml(options.clientName || "An MCP client")
     const userName = escapeHtml(options.userName || "your account")
@@ -60,12 +66,17 @@ export const consentPage = (options: {clientName: string; userName: string; requ
     )
 }
 
+/**
+ * Generic error page for the OAuth consent flow.
+ */
 export const errorPage = (title: string, message: string, href?: string, hrefLabel?: string): string => {
     const link = href ? `<p><a class="btn primary" href="${escapeHtml(href)}">${escapeHtml(hrefLabel || "Continue")}</a></p>` : ""
     return layout(title, `<h2>${escapeHtml(title)}</h2><div class="card"><p>${escapeHtml(message)}</p>${link}</div>`)
 }
 
+/**
+ * Shown when a non-PRO user completes Strava login but cannot authorize MCP access.
+ */
 export const proRequiredPage = (): string => {
     return errorPage("PRO required", "The Strautomator MCP server is available to PRO members only. Upgrade your account, then try connecting again.", "/billing", "Go to billing")
 }
-

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -6,6 +6,9 @@ import {setCorsHeaders} from "./utils"
 import express = require("express")
 import logger from "anyhow"
 
+/**
+ * Apply CORS headers and short-circuit OPTIONS preflight requests.
+ */
 const corsPreflight = (req: express.Request, res: express.Response, next: express.NextFunction) => {
     setCorsHeaders(res)
     if (req.method == "OPTIONS") {
@@ -19,6 +22,7 @@ const corsPreflight = (req: express.Request, res: express.Response, next: expres
  * Register MCP and OAuth endpoints on the Express app. Must run before the Nuxt renderer.
  */
 const setup = (app: express.Express): void => {
+    // RFC 9728 / RFC 8414 metadata at the site root (expected by MCP clients).
     const wellKnown = express.Router()
     wellKnown.use(corsPreflight)
     wellKnown.get("/oauth-protected-resource", oauth.protectedResourceMetadata)
@@ -27,6 +31,7 @@ const setup = (app: express.Express): void => {
     wellKnown.get("/oauth-authorization-server/mcp", oauth.authorizationServerMetadata)
     app.use("/.well-known", wellKnown)
 
+    // OAuth 2.1 authorization server (DCR, authorize, token, revoke).
     const oauthRouter = express.Router()
     oauthRouter.use(corsPreflight)
     oauthRouter.get("/authorize", oauth.authorize)
@@ -36,12 +41,14 @@ const setup = (app: express.Express): void => {
     oauthRouter.post("/revoke", oauth.revoke)
     app.use("/mcp/oauth", oauthRouter)
 
+    // Alternate metadata paths under /mcp (some clients probe here).
     const mcpMeta = express.Router()
     mcpMeta.use(corsPreflight)
     mcpMeta.get("/oauth-protected-resource", oauth.protectedResourceMetadata)
     mcpMeta.get("/oauth-authorization-server", oauth.authorizationServerMetadata)
     app.use("/mcp/.well-known", mcpMeta)
 
+    // MCP Streamable HTTP JSON-RPC endpoint.
     app.options("/mcp", corsPreflight)
     app.get("/mcp", corsPreflight, handleMcp)
     app.post("/mcp", corsPreflight, handleMcp)

--- a/src/mcp/oauth.ts
+++ b/src/mcp/oauth.ts
@@ -430,8 +430,13 @@ export const token = async (req: express.Request, res: express.Response): Promis
             const redirectUri = firstString(req.body?.redirect_uri)
             const codeVerifier = firstString(req.body?.code_verifier)
             const resource = firstString(req.body?.resource)
-            const authCode = await store.consumeAuthCode(code)
 
+            // RFC 8707: reject before touching the authorization code so the client can retry.
+            if (!resource) {
+                return oauthErrorJson(res, 400, "invalid_target", "resource parameter is required and must match the MCP server")
+            }
+
+            const authCode = await store.getAuthCode(code)
             if (!authCode || authCode.clientId != auth.client.id) {
                 return oauthErrorJson(res, 400, "invalid_grant", "Invalid authorization code")
             }
@@ -441,32 +446,45 @@ export const token = async (req: express.Request, res: express.Response): Promis
             if (!verifyPkce(codeVerifier, authCode.codeChallenge)) {
                 return oauthErrorJson(res, 400, "invalid_grant", "PKCE verification failed")
             }
-            // RFC 8707: tokens are audience-bound to the MCP resource URI.
-            if (!resource || !resourceMatches(resource, authCode.resource)) {
+            if (!resourceMatches(resource, authCode.resource)) {
                 return oauthErrorJson(res, 400, "invalid_target", "resource parameter is required and must match the MCP server")
             }
 
-            const tokens = await store.issueTokens({clientId: auth.client.id, userId: authCode.userId, resource: authCode.resource, scope: authCode.scope})
-            logger.info("McpOAuth.token", `User ${authCode.userId}`, `Client ${auth.client.id}`, "authorization_code")
-            res.json({access_token: tokens.accessToken, token_type: "Bearer", expires_in: tokens.expiresIn, refresh_token: tokens.refreshToken, scope: authCode.scope})
+            const consumed = await store.consumeAuthCode(code)
+            if (!consumed) {
+                return oauthErrorJson(res, 400, "invalid_grant", "Invalid authorization code")
+            }
+
+            const tokens = await store.issueTokens({clientId: auth.client.id, userId: consumed.userId, resource: consumed.resource, scope: consumed.scope})
+            logger.info("McpOAuth.token", `User ${consumed.userId}`, `Client ${auth.client.id}`, "authorization_code")
+            res.json({access_token: tokens.accessToken, token_type: "Bearer", expires_in: tokens.expiresIn, refresh_token: tokens.refreshToken, scope: consumed.scope})
             return
         }
 
         if (grantType == "refresh_token") {
             const refreshToken = firstString(req.body?.refresh_token)
             const resource = firstString(req.body?.resource)
-            const existing = await store.consumeRefreshToken(refreshToken)
 
-            if (!existing || existing.clientId != auth.client.id) {
-                return oauthErrorJson(res, 400, "invalid_grant", "Invalid refresh token")
-            }
-            if (!resource || !resourceMatches(resource, existing.resource)) {
+            if (!resource) {
                 return oauthErrorJson(res, 400, "invalid_target", "resource parameter is required and must match the MCP server")
             }
 
-            const tokens = await store.issueTokens({clientId: existing.clientId, userId: existing.userId, resource: existing.resource, scope: existing.scope})
-            logger.info("McpOAuth.token", `User ${existing.userId}`, `Client ${auth.client.id}`, "refresh_token")
-            res.json({access_token: tokens.accessToken, token_type: "Bearer", expires_in: tokens.expiresIn, refresh_token: tokens.refreshToken, scope: existing.scope})
+            const existing = await store.getRefreshToken(refreshToken)
+            if (!existing || existing.clientId != auth.client.id) {
+                return oauthErrorJson(res, 400, "invalid_grant", "Invalid refresh token")
+            }
+            if (!resourceMatches(resource, existing.resource)) {
+                return oauthErrorJson(res, 400, "invalid_target", "resource parameter is required and must match the MCP server")
+            }
+
+            const consumed = await store.consumeRefreshToken(refreshToken)
+            if (!consumed) {
+                return oauthErrorJson(res, 400, "invalid_grant", "Invalid refresh token")
+            }
+
+            const tokens = await store.issueTokens({clientId: consumed.clientId, userId: consumed.userId, resource: consumed.resource, scope: consumed.scope})
+            logger.info("McpOAuth.token", `User ${consumed.userId}`, `Client ${auth.client.id}`, "refresh_token")
+            res.json({access_token: tokens.accessToken, token_type: "Bearer", expires_in: tokens.expiresIn, refresh_token: tokens.refreshToken, scope: consumed.scope})
             return
         }
 

--- a/src/mcp/oauth.ts
+++ b/src/mcp/oauth.ts
@@ -11,12 +11,22 @@ import logger from "anyhow"
 import dayjs from "../dayjs"
 const sessions = require("client-sessions")
 
+/** Grant types advertised and accepted by this authorization server. */
 const supportedGrantTypes = ["authorization_code", "refresh_token"]
+/** Response types supported on the authorize endpoint. */
 const supportedResponseTypes = ["code"]
+/** Token endpoint client authentication methods (public clients use "none"). */
 const supportedAuthMethods = ["none", "client_secret_post", "client_secret_basic"]
 
+/** Lazy-initialized session middleware (same cookie as the Strava login flow). */
 let sessionMiddleware: express.RequestHandler
 
+// SESSION
+// --------------------------------------------------------------------------
+
+/**
+ * Return the client-sessions middleware used to read the Strava login cookie on the consent page.
+ */
 const getSessionMiddleware = (): express.RequestHandler => {
     if (!sessionMiddleware) {
         const config = getMcpConfig()
@@ -29,12 +39,21 @@ const getSessionMiddleware = (): express.RequestHandler => {
     return sessionMiddleware
 }
 
+/**
+ * Wrap a route handler so the Strava session cookie is available on the request.
+ */
 const withSession = (handler: express.RequestHandler): express.RequestHandler => {
     return (req, res, next) => {
         getSessionMiddleware()(req, res, () => handler(req, res, next))
     }
 }
 
+// INTERNAL HELPERS
+// --------------------------------------------------------------------------
+
+/**
+ * Redirect back to the MCP client with OAuth query parameters (code or error).
+ */
 const oauthRedirect = (res: express.Response, redirectUri: string, params: Record<string, string>): void => {
     const url = new URL(redirectUri)
     for (const [key, value] of Object.entries(params)) {
@@ -45,10 +64,16 @@ const oauthRedirect = (res: express.Response, redirectUri: string, params: Recor
     res.redirect(302, url.toString())
 }
 
+/**
+ * Send a JSON OAuth error response.
+ */
 const oauthErrorJson = (res: express.Response, status: number, error: string, description: string): void => {
     res.status(status).json({error, error_description: description})
 }
 
+/**
+ * Parse client_id and client_secret from an HTTP Basic Authorization header.
+ */
 const parseBasicClient = (req: express.Request): {clientId?: string; clientSecret?: string} => {
     const header = req.headers.authorization || ""
     if (!header.toLowerCase().startsWith("basic ")) {
@@ -67,6 +92,10 @@ const parseBasicClient = (req: express.Request): {clientId?: string; clientSecre
     }
 }
 
+/**
+ * Authenticate the OAuth client on the token and revoke endpoints.
+ * Public clients (token_endpoint_auth_method "none") skip secret validation.
+ */
 const authenticateClient = async (req: express.Request): Promise<{client: McpOAuthClient; error?: string}> => {
     const basic = parseBasicClient(req)
     const clientId = firstString(req.body?.client_id) || basic.clientId
@@ -93,6 +122,10 @@ const authenticateClient = async (req: express.Request): Promise<{client: McpOAu
     return {client}
 }
 
+/**
+ * Resolve the logged-in Strautomator user from the Strava session cookie.
+ * Returns null when the user has not signed in yet.
+ */
 const getLoggedUser = async (req: express.Request): Promise<UserData> => {
     const config = getMcpConfig()
     const session = (req as any)[config.cookieName]
@@ -109,6 +142,9 @@ const getLoggedUser = async (req: express.Request): Promise<UserData> => {
     }
 }
 
+/**
+ * Compare two resource indicator URIs, ignoring trailing slashes.
+ */
 const resourceMatches = (requested: string, expected: string): boolean => {
     if (!requested) {
         return true
@@ -117,6 +153,9 @@ const resourceMatches = (requested: string, expected: string): boolean => {
     const b = expected.replace(/\/+$/, "")
     return a == b
 }
+
+// METADATA
+// --------------------------------------------------------------------------
 
 /**
  * Protected resource metadata (RFC 9728).
@@ -154,6 +193,9 @@ export const authorizationServerMetadata = (_req: express.Request, res: express.
         resource_indicators_supported: true
     })
 }
+
+// DYNAMIC CLIENT REGISTRATION
+// --------------------------------------------------------------------------
 
 /**
  * Dynamic client registration (RFC 7591).
@@ -209,6 +251,7 @@ export const registerClient = async (req: express.Request, res: express.Response
         const result: any = {
             client_id: client.id,
             client_id_issued_at: now.unix(),
+            // Public clients have no secret (0). Confidential clients expire with the registration.
             client_secret_expires_at: confidential ? dayjs(client.dateExpiry).unix() : 0,
             redirect_uris: client.redirectUris,
             grant_types: client.grantTypes,
@@ -228,6 +271,10 @@ export const registerClient = async (req: express.Request, res: express.Response
     }
 }
 
+/**
+ * Validate the authorize query string and persist a pending authorization request.
+ * The request survives the Strava login redirect and is referenced by request_id.
+ */
 const createAuthRequest = async (req: express.Request): Promise<{request?: McpAuthRequest; error?: string; description?: string; redirectUri?: string; state?: string}> => {
     const config = getMcpConfig()
     const clientId = firstString(req.query.client_id)
@@ -270,8 +317,12 @@ const createAuthRequest = async (req: express.Request): Promise<{request?: McpAu
     return {request}
 }
 
+// AUTHORIZATION
+// --------------------------------------------------------------------------
+
 /**
- * Authorization endpoint (authorization code + PKCE). GET shows consent; POST records the decision.
+ * Authorization endpoint (authorization code + PKCE).
+ * GET shows the consent page; POST records the user's decision.
  */
 export const authorize = withSession(async (req: express.Request, res: express.Response): Promise<void> => {
     const config = getMcpConfig()
@@ -281,12 +332,14 @@ export const authorize = withSession(async (req: express.Request, res: express.R
         const requestId = firstString(req.body?.request_id) || firstString(req.query.request_id)
 
         if (requestId) {
+            // Resume a pending request (after Strava login or after the canonical redirect).
             request = await store.getAuthRequest(requestId)
             if (!request) {
                 res.status(400).send(errorPage("Authorization expired", "This authorization request is no longer valid. Start the connection again from your MCP client."))
                 return
             }
         } else if (req.method == "GET") {
+            // First visit from the MCP client: validate params, persist, then redirect to a stable URL.
             const created = await createAuthRequest(req)
             if (created.error) {
                 if (created.redirectUri) {
@@ -296,6 +349,7 @@ export const authorize = withSession(async (req: express.Request, res: express.R
                 res.status(400).send(errorPage("Invalid request", created.description || created.error))
                 return
             }
+            // Canonical URL so refreshing the consent page does not invalidate the consent_token.
             res.redirect(302, `/mcp/oauth/authorize?request_id=${encodeURIComponent(created.request.id)}`)
             return
         } else {
@@ -352,8 +406,11 @@ export const authorize = withSession(async (req: express.Request, res: express.R
     }
 })
 
+// TOKEN ENDPOINT
+// --------------------------------------------------------------------------
+
 /**
- * Token endpoint.
+ * Token endpoint (authorization_code and refresh_token grants).
  */
 export const token = async (req: express.Request, res: express.Response): Promise<void> => {
     setCorsHeaders(res)
@@ -384,6 +441,7 @@ export const token = async (req: express.Request, res: express.Response): Promis
             if (!verifyPkce(codeVerifier, authCode.codeChallenge)) {
                 return oauthErrorJson(res, 400, "invalid_grant", "PKCE verification failed")
             }
+            // RFC 8707: tokens are audience-bound to the MCP resource URI.
             if (!resource || !resourceMatches(resource, authCode.resource)) {
                 return oauthErrorJson(res, 400, "invalid_target", "resource parameter is required and must match the MCP server")
             }
@@ -420,7 +478,7 @@ export const token = async (req: express.Request, res: express.Response): Promis
 }
 
 /**
- * Token revocation (RFC 7009).
+ * Token revocation (RFC 7009). Always returns 200 per the spec, even on errors.
  */
 export const revoke = async (req: express.Request, res: express.Response): Promise<void> => {
     setCorsHeaders(res)

--- a/src/mcp/oauth.ts
+++ b/src/mcp/oauth.ts
@@ -209,7 +209,7 @@ export const registerClient = async (req: express.Request, res: express.Response
         const result: any = {
             client_id: client.id,
             client_id_issued_at: now.unix(),
-            client_secret_expires_at: 0,
+            client_secret_expires_at: confidential ? dayjs(client.dateExpiry).unix() : 0,
             redirect_uris: client.redirectUris,
             grant_types: client.grantTypes,
             response_types: client.responseTypes,
@@ -296,7 +296,8 @@ export const authorize = withSession(async (req: express.Request, res: express.R
                 res.status(400).send(errorPage("Invalid request", created.description || created.error))
                 return
             }
-            request = created.request
+            res.redirect(302, `/mcp/oauth/authorize?request_id=${encodeURIComponent(created.request.id)}`)
+            return
         } else {
             res.status(400).send(errorPage("Invalid request", "Missing authorization request."))
             return
@@ -383,8 +384,8 @@ export const token = async (req: express.Request, res: express.Response): Promis
             if (!verifyPkce(codeVerifier, authCode.codeChallenge)) {
                 return oauthErrorJson(res, 400, "invalid_grant", "PKCE verification failed")
             }
-            if (resource && !resourceMatches(resource, authCode.resource)) {
-                return oauthErrorJson(res, 400, "invalid_target", "resource mismatch")
+            if (!resource || !resourceMatches(resource, authCode.resource)) {
+                return oauthErrorJson(res, 400, "invalid_target", "resource parameter is required and must match the MCP server")
             }
 
             const tokens = await store.issueTokens({clientId: auth.client.id, userId: authCode.userId, resource: authCode.resource, scope: authCode.scope})
@@ -401,8 +402,8 @@ export const token = async (req: express.Request, res: express.Response): Promis
             if (!existing || existing.clientId != auth.client.id) {
                 return oauthErrorJson(res, 400, "invalid_grant", "Invalid refresh token")
             }
-            if (resource && !resourceMatches(resource, existing.resource)) {
-                return oauthErrorJson(res, 400, "invalid_target", "resource mismatch")
+            if (!resource || !resourceMatches(resource, existing.resource)) {
+                return oauthErrorJson(res, 400, "invalid_target", "resource parameter is required and must match the MCP server")
             }
 
             const tokens = await store.issueTokens({clientId: existing.clientId, userId: existing.userId, resource: existing.resource, scope: existing.scope})

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -9,10 +9,20 @@ import express = require("express")
 import logger from "anyhow"
 const packageVersion = require("../../package.json").version
 
+// INTERNAL HELPERS
+// --------------------------------------------------------------------------
+
+/**
+ * Build a JSON-RPC 2.0 error response.
+ */
 const jsonRpcError = (id: JsonRpcRequest["id"], code: number, message: string): JsonRpcResponse => {
     return {jsonrpc: "2.0", id: id ?? null, error: {code, message}}
 }
 
+/**
+ * Authenticate the MCP request using the OAuth bearer token issued by this server.
+ * Strava tokens are never accepted here.
+ */
 const authenticateRequest = async (req: express.Request, res: express.Response): Promise<UserData> => {
     const header = req.headers.authorization || ""
     const match = header.match(/^Bearer\s+(.+)$/i)
@@ -44,6 +54,9 @@ const authenticateRequest = async (req: express.Request, res: express.Response):
     return user
 }
 
+/**
+ * Dispatch a single JSON-RPC message for the authenticated user.
+ */
 const handleRpc = async (user: UserData, message: JsonRpcRequest): Promise<JsonRpcResponse> => {
     const id = message?.id ?? null
     if (!message || message.jsonrpc != "2.0" || !message.method) {
@@ -85,10 +98,12 @@ const handleRpc = async (user: UserData, message: JsonRpcRequest): Promise<JsonR
         return {jsonrpc: "2.0", id, result}
     }
 
+    // Client notifications do not expect a response.
     if (message.method == "notifications/initialized" || message.method.startsWith("notifications/")) {
         return null
     }
 
+    // Advertise empty resource and prompt lists (tools-only server).
     if (message.method == "resources/list") {
         return {jsonrpc: "2.0", id, result: {resources: []}}
     }
@@ -99,8 +114,11 @@ const handleRpc = async (user: UserData, message: JsonRpcRequest): Promise<JsonR
     return jsonRpcError(id, -32601, `Method not found: ${message.method}`)
 }
 
+// STREAMABLE HTTP
+// --------------------------------------------------------------------------
+
 /**
- * Handle MCP Streamable HTTP requests.
+ * Handle MCP Streamable HTTP requests (POST /mcp).
  */
 export const handleMcp = async (req: express.Request, res: express.Response): Promise<void> => {
     setCorsHeaders(res)
@@ -110,6 +128,7 @@ export const handleMcp = async (req: express.Request, res: express.Response): Pr
         return
     }
 
+    // Stateless server: only POST carries JSON-RPC payloads.
     if (req.method == "GET" || req.method == "DELETE") {
         res.status(405).setHeader("Allow", "POST, OPTIONS").json({error: "method_not_allowed", error_description: "This MCP server is stateless and only accepts POST"})
         return
@@ -134,6 +153,7 @@ export const handleMcp = async (req: express.Request, res: express.Response): Pr
             }
         }
 
+        // Notification-only batches return 202 with no body.
         if (responses.length == 0) {
             res.status(202).send()
             return

--- a/src/mcp/store.ts
+++ b/src/mcp/store.ts
@@ -121,7 +121,29 @@ export class McpStore {
     }
 
     /**
-     * Consume an authorization code (delete-first, then validate). Returns null if missing or expired.
+     * Load an authorization code without consuming it. Expired codes are deleted and return null.
+     */
+    getAuthCode = async (code: string): Promise<McpAuthCode> => {
+        if (!code) {
+            return null
+        }
+
+        const id = hashToken(code)
+        const doc: McpAuthCode = await database.get(COL_CODES, id)
+        if (!doc) {
+            return null
+        }
+        if (isExpired(doc)) {
+            await database.delete(COL_CODES, id)
+            return null
+        }
+
+        return doc
+    }
+
+    /**
+     * Consume an authorization code after the token request has been fully validated.
+     * Deletes the code before returning so concurrent exchanges cannot both succeed.
      */
     consumeAuthCode = async (code: string): Promise<McpAuthCode> => {
         if (!code) {
@@ -203,7 +225,29 @@ export class McpStore {
     }
 
     /**
+     * Load a refresh token without consuming it. Expired tokens are deleted and return null.
+     */
+    getRefreshToken = async (refreshToken: string): Promise<McpToken> => {
+        if (!refreshToken) {
+            return null
+        }
+
+        const id = hashToken(refreshToken)
+        const doc: McpToken = await database.get(COL_TOKENS, id)
+        if (!doc || doc.type != "refresh") {
+            return null
+        }
+        if (isExpired(doc)) {
+            await database.delete(COL_TOKENS, id)
+            return null
+        }
+
+        return doc
+    }
+
+    /**
      * Consume a refresh token (rotation). Deletes the refresh token and its paired access token.
+     * Call only after the token request has been fully validated.
      */
     consumeRefreshToken = async (refreshToken: string): Promise<McpToken> => {
         if (!refreshToken) {

--- a/src/mcp/store.ts
+++ b/src/mcp/store.ts
@@ -143,7 +143,7 @@ export class McpStore {
 
     /**
      * Consume an authorization code after the token request has been fully validated.
-     * Deletes the code before returning so concurrent exchanges cannot both succeed.
+     * Uses a Firestore transaction so only one concurrent exchange can succeed.
      */
     consumeAuthCode = async (code: string): Promise<McpAuthCode> => {
         if (!code) {
@@ -151,14 +151,20 @@ export class McpStore {
         }
 
         const id = hashToken(code)
-        const doc: McpAuthCode = await database.get(COL_CODES, id)
-        await database.delete(COL_CODES, id)
 
-        if (!doc || isExpired(doc)) {
-            return null
-        }
+        return database.runTransaction(async (tx) => {
+            const doc: McpAuthCode = await tx.get(COL_CODES, id)
+            if (!doc) {
+                return null
+            }
 
-        return doc
+            tx.delete(COL_CODES, id)
+            if (isExpired(doc)) {
+                return null
+            }
+
+            return doc
+        })
     }
 
     // TOKENS
@@ -246,8 +252,8 @@ export class McpStore {
     }
 
     /**
-     * Consume a refresh token (rotation). Deletes the refresh token and its paired access token.
-     * Call only after the token request has been fully validated.
+     * Consume a refresh token (rotation). Deletes the refresh token and its paired access token
+     * inside a Firestore transaction so only one concurrent refresh can succeed.
      */
     consumeRefreshToken = async (refreshToken: string): Promise<McpToken> => {
         if (!refreshToken) {
@@ -255,25 +261,28 @@ export class McpStore {
         }
 
         const id = hashToken(refreshToken)
-        const doc: McpToken = await database.get(COL_TOKENS, id)
-        if (!doc || doc.type != "refresh") {
+
+        try {
+            return await database.runTransaction(async (tx) => {
+                const doc: McpToken = await tx.get(COL_TOKENS, id)
+                if (!doc || doc.type != "refresh") {
+                    return null
+                }
+
+                tx.delete(COL_TOKENS, id)
+                if (doc.accessId) {
+                    tx.delete(COL_TOKENS, doc.accessId)
+                }
+                if (isExpired(doc)) {
+                    return null
+                }
+
+                return doc
+            })
+        } catch (ex) {
+            logger.error("McpStore.consumeRefreshToken", id, ex)
             return null
         }
-        if (isExpired(doc)) {
-            await database.delete(COL_TOKENS, id)
-            return null
-        }
-
-        await database.delete(COL_TOKENS, id)
-        if (doc.accessId) {
-            try {
-                await database.delete(COL_TOKENS, doc.accessId)
-            } catch (ex) {
-                logger.warn("McpStore.consumeRefreshToken", "Failed to delete previous access token", ex)
-            }
-        }
-
-        return doc
     }
 
     /**

--- a/src/mcp/store.ts
+++ b/src/mcp/store.ts
@@ -6,11 +6,18 @@ import {getMcpConfig, hashToken, randomToken} from "./utils"
 import dayjs from "../dayjs"
 import logger from "anyhow"
 
+/** Firestore collection for dynamically registered OAuth clients. */
 const COL_CLIENTS = "mcp-clients"
+/** Firestore collection for pending authorization requests (consent flow). */
 const COL_REQUESTS = "mcp-auth-requests"
+/** Firestore collection for single-use authorization codes. */
 const COL_CODES = "mcp-auth-codes"
+/** Firestore collection for issued access and refresh tokens (stored hashed). */
 const COL_TOKENS = "mcp-tokens"
 
+/**
+ * Whether a persisted document has passed its dateExpiry.
+ */
 const isExpired = (doc: {dateExpiry?: Date}): boolean => {
     if (!doc?.dateExpiry) {
         return true
@@ -31,11 +38,17 @@ export class McpStore {
     // CLIENTS
     // --------------------------------------------------------------------------
 
+    /**
+     * Persist a dynamically registered OAuth client.
+     */
     saveClient = async (client: McpOAuthClient): Promise<void> => {
         await database.set(COL_CLIENTS, client, client.id)
         logger.info("McpStore.saveClient", client.id, client.clientName || "unnamed", client.tokenEndpointAuthMethod)
     }
 
+    /**
+     * Load a registered client by ID. Expired registrations are deleted and return null.
+     */
     getClient = async (clientId: string): Promise<McpOAuthClient> => {
         if (!clientId) {
             return null
@@ -56,10 +69,16 @@ export class McpStore {
     // AUTH REQUESTS
     // --------------------------------------------------------------------------
 
+    /**
+     * Save a pending authorization request while the user signs in or reviews consent.
+     */
     saveAuthRequest = async (request: McpAuthRequest): Promise<void> => {
         await database.set(COL_REQUESTS, request, request.id)
     }
 
+    /**
+     * Load a pending authorization request. Expired requests are deleted and return null.
+     */
     getAuthRequest = async (id: string): Promise<McpAuthRequest> => {
         if (!id) {
             return null
@@ -77,6 +96,9 @@ export class McpStore {
         return request
     }
 
+    /**
+     * Remove a pending authorization request after consent or denial.
+     */
     deleteAuthRequest = async (id: string): Promise<void> => {
         try {
             await database.delete(COL_REQUESTS, id)
@@ -88,6 +110,9 @@ export class McpStore {
     // AUTH CODES
     // --------------------------------------------------------------------------
 
+    /**
+     * Issue a single-use authorization code. Only the SHA-256 hash is stored.
+     */
     issueAuthCode = async (data: Omit<McpAuthCode, "id">): Promise<string> => {
         const code = randomToken(32)
         const doc: McpAuthCode = {id: hashToken(code), ...data}
@@ -95,6 +120,9 @@ export class McpStore {
         return code
     }
 
+    /**
+     * Consume an authorization code (delete-first, then validate). Returns null if missing or expired.
+     */
     consumeAuthCode = async (code: string): Promise<McpAuthCode> => {
         if (!code) {
             return null
@@ -114,6 +142,10 @@ export class McpStore {
     // TOKENS
     // --------------------------------------------------------------------------
 
+    /**
+     * Issue a new access/refresh token pair. Previous tokens for the same grant are not affected
+     * until the refresh token is consumed or revoked.
+     */
     issueTokens = async (data: {clientId: string; userId: string; resource: string; scope: string}): Promise<{accessToken: string; refreshToken: string; expiresIn: number}> => {
         const config = getMcpConfig()
         const accessToken = `mcp_at_${randomToken(32)}`
@@ -149,6 +181,9 @@ export class McpStore {
         return {accessToken, refreshToken, expiresIn: config.accessTokenHours * 3600}
     }
 
+    /**
+     * Validate a bearer access token for MCP requests. Expired tokens are deleted on read.
+     */
     getAccessToken = async (accessToken: string): Promise<McpToken> => {
         if (!accessToken) {
             return null
@@ -167,6 +202,9 @@ export class McpStore {
         return doc
     }
 
+    /**
+     * Consume a refresh token (rotation). Deletes the refresh token and its paired access token.
+     */
     consumeRefreshToken = async (refreshToken: string): Promise<McpToken> => {
         if (!refreshToken) {
             return null
@@ -194,6 +232,9 @@ export class McpStore {
         return doc
     }
 
+    /**
+     * Revoke an access or refresh token and its paired token, if present.
+     */
     revokeToken = async (token: string): Promise<void> => {
         if (!token) {
             return

--- a/src/mcp/store.ts
+++ b/src/mcp/store.ts
@@ -262,27 +262,22 @@ export class McpStore {
 
         const id = hashToken(refreshToken)
 
-        try {
-            return await database.runTransaction(async (tx) => {
-                const doc: McpToken = await tx.get(COL_TOKENS, id)
-                if (!doc || doc.type != "refresh") {
-                    return null
-                }
+        return database.runTransaction(async (tx) => {
+            const doc: McpToken = await tx.get(COL_TOKENS, id)
+            if (!doc || doc.type != "refresh") {
+                return null
+            }
 
-                tx.delete(COL_TOKENS, id)
-                if (doc.accessId) {
-                    tx.delete(COL_TOKENS, doc.accessId)
-                }
-                if (isExpired(doc)) {
-                    return null
-                }
+            tx.delete(COL_TOKENS, id)
+            if (doc.accessId) {
+                tx.delete(COL_TOKENS, doc.accessId)
+            }
+            if (isExpired(doc)) {
+                return null
+            }
 
-                return doc
-            })
-        } catch (ex) {
-            logger.error("McpStore.consumeRefreshToken", id, ex)
-            return null
-        }
+            return doc
+        })
     }
 
     /**

--- a/src/mcp/store.ts
+++ b/src/mcp/store.ts
@@ -154,8 +154,13 @@ export class McpStore {
             return null
         }
 
-        const doc: McpToken = await database.get(COL_TOKENS, hashToken(accessToken))
-        if (!doc || doc.type != "access" || isExpired(doc)) {
+        const id = hashToken(accessToken)
+        const doc: McpToken = await database.get(COL_TOKENS, id)
+        if (!doc || doc.type != "access") {
+            return null
+        }
+        if (isExpired(doc)) {
+            await database.delete(COL_TOKENS, id)
             return null
         }
 
@@ -169,7 +174,11 @@ export class McpStore {
 
         const id = hashToken(refreshToken)
         const doc: McpToken = await database.get(COL_TOKENS, id)
-        if (!doc || doc.type != "refresh" || isExpired(doc)) {
+        if (!doc || doc.type != "refresh") {
+            return null
+        }
+        if (isExpired(doc)) {
+            await database.delete(COL_TOKENS, id)
             return null
         }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -14,6 +14,13 @@ interface ToolDef {
     handler: ToolHandler
 }
 
+// TOOL DEFINITIONS
+// --------------------------------------------------------------------------
+
+/**
+ * MCP tool catalog. Each handler delegates to src/routes/logic.ts or the equivalent core module
+ * so behaviour stays aligned with the website API.
+ */
 const tools: ToolDef[] = [
     {
         name: "get_account",
@@ -77,6 +84,7 @@ const tools: ToolDef[] = [
         name: "get_automation_schema",
         description: "Return valid automation condition properties, operators and action types from core. Call this before save_automation.",
         inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        // Full core lists (not filtered by isPro) because MCP access is already PRO-only.
         handler: async () => ({properties: recipes.propertyList, actions: recipes.actionList})
     },
     {
@@ -196,10 +204,19 @@ const tools: ToolDef[] = [
     }
 ]
 
+// EXPORTS
+// --------------------------------------------------------------------------
+
+/**
+ * Return the MCP tool list (name, description and JSON Schema) for tools/list.
+ */
 export const listTools = () => {
     return tools.map((t) => ({name: t.name, description: t.description, inputSchema: t.inputSchema}))
 }
 
+/**
+ * Execute a tool by name for the authenticated user.
+ */
 export const callTool = async (user: UserData, name: string, args: any) => {
     const tool = tools.find((t) => t.name == name)
     if (!tool) {

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -1,5 +1,8 @@
 // Strautomator MCP types
 
+// OAUTH PERSISTENCE
+// --------------------------------------------------------------------------
+
 export interface McpOAuthClient {
     /** Client ID (document ID). */
     id: string
@@ -83,6 +86,9 @@ export interface McpToken {
     /** Date this token expires. */
     dateExpiry: Date
 }
+
+// MCP PROTOCOL
+// --------------------------------------------------------------------------
 
 export interface McpToolResult {
     content: {type: "text"; text: string}[]

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -4,6 +4,9 @@ import crypto from "crypto"
 import _ from "lodash"
 import type {UserData} from "strautomator-core"
 
+// CONFIG
+// --------------------------------------------------------------------------
+
 /**
  * MCP runtime config derived from SetMeUp settings.
  */
@@ -28,6 +31,9 @@ export const getMcpConfig = () => {
         protocolVersions: ["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"]
     }
 }
+
+// TOKENS AND PKCE
+// --------------------------------------------------------------------------
 
 /**
  * Encode a buffer as base64url (no padding).
@@ -87,6 +93,9 @@ export const verifyPkce = (verifier: string, challenge: string): boolean => {
     return crypto.timingSafeEqual(a, b)
 }
 
+// OAUTH VALIDATION
+// --------------------------------------------------------------------------
+
 /**
  * Whether a redirect URI is acceptable for dynamic client registration.
  */
@@ -126,6 +135,9 @@ export const isValidRedirectUri = (value: string): boolean => {
 
     return false
 }
+
+// REQUEST / RESPONSE HELPERS
+// --------------------------------------------------------------------------
 
 /**
  * Escape text for safe use in HTML.
@@ -177,6 +189,9 @@ export const sanitizeUser = (user: UserData): any => {
     return result
 }
 
+// MCP TOOL PAYLOADS
+// --------------------------------------------------------------------------
+
 /**
  * JSON-serialize a value, converting dates to ISO strings.
  */
@@ -206,6 +221,9 @@ export const toolResult = (data: any) => {
 export const toolError = (message: string) => {
     return {content: [{type: "text" as const, text: message}], isError: true}
 }
+
+// HTTP HEADERS
+// --------------------------------------------------------------------------
 
 /**
  * Apply CORS headers required by browser-based MCP clients.

--- a/src/routes/logic.ts
+++ b/src/routes/logic.ts
@@ -7,6 +7,9 @@ import _ from "lodash"
 import logger from "anyhow"
 const settings = require("setmeup").settings
 
+// USER
+// --------------------------------------------------------------------------
+
 /**
  * Public user payload returned by GET /api/users/:userId.
  */
@@ -56,6 +59,9 @@ export const getPublicUser = async (user: UserData, refresh?: boolean): Promise<
 
     return result
 }
+
+// RECIPES
+// --------------------------------------------------------------------------
 
 /**
  * Create, update or delete a user automation (same as POST/DELETE /api/users/:userId/recipes).
@@ -141,6 +147,9 @@ export const getRecipeStats = async (user: UserData, recipeId?: string): Promise
     return arrStats
 }
 
+// STRAVA
+// --------------------------------------------------------------------------
+
 /**
  * Processed activities returned by GET /api/strava/:userId/processed-activities.
  */
@@ -185,6 +194,9 @@ export const saveEstimatedFtp = async (user: UserData, ftp?: number): Promise<an
     const updated = await strava.performance.saveFtp(user, estimation)
     return updated ? {ftp: estimation.ftpWatts} : false
 }
+
+// GEARWEAR
+// --------------------------------------------------------------------------
 
 /**
  * GearWear list returned by GET /api/gearwear/:userId.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up fixes for the MCP server ([PR #46](https://github.com/strautomator/web/pull/46)) before production rollout.

## Changes

### Consent page survives refresh
After creating a pending authorization request, redirect to `/mcp/oauth/authorize?request_id=…` instead of rendering the consent form immediately.

### Accurate client registration metadata
Confidential OAuth clients now return `client_secret_expires_at` aligned with the stored `clientDays` expiry.

### Tighter token endpoint validation
The `resource` parameter is required on both `authorization_code` and `refresh_token` grants (RFC 8707 audience binding).

### Grants are not burned on invalid_target
Authorization codes and refresh tokens are peeked and validated before consumption. Missing or mismatched `resource` returns `invalid_target` without deleting the grant.

### Atomic grant consumption
`consumeAuthCode` and `consumeRefreshToken` use `database.runTransaction()` so only one concurrent token exchange can succeed per grant. Requires [core PR #86](https://github.com/strautomator/core/pull/86).

### Firestore cleanup
Expired access and refresh tokens are deleted on read.

### Code documentation
Section headers, JSDoc, and inline comments across the MCP module and shared `src/routes/logic.ts`.

## Testing

- `npx tsc --noEmit`
- `npx tsx src/mcp/utils.spec.ts`

Live OAuth round-trip still recommended after deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5773b352-0fa5-43ae-b360-4eef19071fde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5773b352-0fa5-43ae-b360-4eef19071fde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

