### PR TITLE
Improve MCP account and activity tools

### DIFF
--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,8 +1,9 @@
 // Strautomator MCP tools — thin wrappers around the same handlers used by the HTTP API.
 
-import {database, notifications, recipes, strava, users, UserData} from "strautomator-core"
+import {calendar, database, notifications, recipes, strava, users, StravaEstimatedFtp, UserData} from "strautomator-core"
 import {getGearwearById, getGearwearByUser, getProcessedActivities, getPublicUser, getRecipeStats, saveEstimatedFtp, upsertUserRecipe} from "../routes/logic"
 import {sanitizeUser, toolError, toolResult} from "./utils"
+import dayjs from "../dayjs"
 import logger from "anyhow"
 
 type ToolHandler = (user: UserData, args: any) => Promise<any>
@@ -12,6 +13,37 @@ interface ToolDef {
     description: string
     inputSchema: any
     handler: ToolHandler
+}
+
+interface CachedFtpEstimate {
+    id: string
+    estimation: StravaEstimatedFtp | false
+    dateEstimated: Date
+    dateExpiry: Date
+}
+
+const FTP_ESTIMATE_COLLECTION = "mcp-ftp-estimates"
+const FTP_ESTIMATE_CACHE_DAYS = 7
+
+const getCachedFtpEstimate = async (user: UserData): Promise<StravaEstimatedFtp | false> => {
+    const cached: CachedFtpEstimate = await database.get(FTP_ESTIMATE_COLLECTION, user.id)
+    if (cached?.dateExpiry && dayjs(cached.dateExpiry).isAfter(dayjs()) && Object.prototype.hasOwnProperty.call(cached, "estimation")) {
+        return cached.estimation
+    }
+
+    const estimation = (await strava.performance.estimateFtp(user)) || false
+    const dateEstimated = new Date()
+    await database.set(
+        FTP_ESTIMATE_COLLECTION,
+        {
+            id: user.id,
+            estimation,
+            dateEstimated,
+            dateExpiry: dayjs(dateEstimated).add(FTP_ESTIMATE_CACHE_DAYS, "days").toDate()
+        } as CachedFtpEstimate,
+        user.id
+    )
+    return estimation
 }
 
 // TOOL DEFINITIONS
@@ -24,7 +56,7 @@ interface ToolDef {
 const tools: ToolDef[] = [
     {
         name: "get_account",
-        description: "Get the authenticated Strautomator user profile, preferences, automations and linked accounts. Secrets and API tokens are omitted.",
+        description: "Get the authenticated Strautomator user profile, preferences and linked accounts. Secrets, API tokens, automations and FIT device names are omitted.",
         inputSchema: {
             type: "object",
             properties: {refresh: {type: "boolean", description: "If true, refresh the Strava profile first (same as GET /api/users/:userId?refresh=1)"}},
@@ -79,6 +111,12 @@ const tools: ToolDef[] = [
             const result = await getPublicUser(user)
             return result.recipes || {}
         }
+    },
+    {
+        name: "list_fit_device_names",
+        description: "List the custom names assigned to FIT device IDs in the user's account.",
+        inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        handler: async (user) => user.fitDeviceNames || {}
     },
     {
         name: "get_automation_schema",
@@ -140,7 +178,7 @@ const tools: ToolDef[] = [
     },
     {
         name: "list_gearwear",
-        description: "List GearWear configurations for the user. Same as GET /api/gearwear/:userId.",
+        description: "List GearWear configurations and device battery tracking information for the user. Same as GET /api/gearwear/:userId.",
         inputSchema: {
             type: "object",
             properties: {refresh: {type: "boolean", description: "If true, refresh gear details from Strava in the background"}},
@@ -167,7 +205,7 @@ const tools: ToolDef[] = [
     },
     {
         name: "estimate_ftp",
-        description: "Estimate cycling FTP from recent activities with power. Same as GET /api/strava/:userId/ftp/estimate. Set save=true to write it to Strava (POST).",
+        description: "Estimate cycling FTP from recent activities with power. Results are cached for 7 days. Set save=true to write the estimate to Strava.",
         inputSchema: {
             type: "object",
             properties: {
@@ -177,11 +215,18 @@ const tools: ToolDef[] = [
             additionalProperties: false
         },
         handler: async (user, args) => {
+            const estimation = await getCachedFtpEstimate(user)
             if (args.save) {
-                return saveEstimatedFtp(user, args.ftp)
+                return estimation ? saveEstimatedFtp(user, args.ftp, estimation) : false
             }
-            return (await strava.performance.estimateFtp(user)) || false
+            return estimation
         }
+    },
+    {
+        name: "list_calendars",
+        description: "List metadata for the user's generated calendars without returning calendar contents.",
+        inputSchema: {type: "object", properties: {}, additionalProperties: false},
+        handler: async (user) => calendar.getByUser(user)
     },
     {
         name: "list_notifications",

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -17,7 +17,7 @@ interface ToolDef {
 
 interface CachedFtpEstimate {
     id: string
-    estimation: StravaEstimatedFtp | false
+    estimation: StravaEstimatedFtp
     dateEstimated: Date
     dateExpiry: Date
 }
@@ -27,11 +27,15 @@ const FTP_ESTIMATE_CACHE_DAYS = 7
 
 const getCachedFtpEstimate = async (user: UserData): Promise<{estimation: StravaEstimatedFtp | false; cached: boolean}> => {
     const cached: CachedFtpEstimate = await database.get(FTP_ESTIMATE_COLLECTION, user.id)
-    if (cached?.dateExpiry && dayjs(cached.dateExpiry).isAfter(dayjs()) && Object.prototype.hasOwnProperty.call(cached, "estimation")) {
+    if (cached?.estimation && cached.dateExpiry && dayjs(cached.dateExpiry).isAfter(dayjs())) {
         return {estimation: cached.estimation, cached: true}
     }
 
-    const estimation = (await strava.performance.estimateFtp(user)) || false
+    const estimation = await strava.performance.estimateFtp(user)
+    if (!estimation) {
+        return {estimation: false, cached: false}
+    }
+
     const dateEstimated = new Date()
     await database.set(
         FTP_ESTIMATE_COLLECTION,

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -25,10 +25,10 @@ interface CachedFtpEstimate {
 const FTP_ESTIMATE_COLLECTION = "mcp-ftp-estimates"
 const FTP_ESTIMATE_CACHE_DAYS = 7
 
-const getCachedFtpEstimate = async (user: UserData): Promise<StravaEstimatedFtp | false> => {
+const getCachedFtpEstimate = async (user: UserData): Promise<{estimation: StravaEstimatedFtp | false; cached: boolean}> => {
     const cached: CachedFtpEstimate = await database.get(FTP_ESTIMATE_COLLECTION, user.id)
     if (cached?.dateExpiry && dayjs(cached.dateExpiry).isAfter(dayjs()) && Object.prototype.hasOwnProperty.call(cached, "estimation")) {
-        return cached.estimation
+        return {estimation: cached.estimation, cached: true}
     }
 
     const estimation = (await strava.performance.estimateFtp(user)) || false
@@ -43,7 +43,7 @@ const getCachedFtpEstimate = async (user: UserData): Promise<StravaEstimatedFtp 
         } as CachedFtpEstimate,
         user.id
     )
-    return estimation
+    return {estimation, cached: false}
 }
 
 // TOOL DEFINITIONS
@@ -205,7 +205,7 @@ const tools: ToolDef[] = [
     },
     {
         name: "estimate_ftp",
-        description: "Estimate cycling FTP from recent activities with power. Results are cached for 7 days. Set save=true to write the estimate to Strava.",
+        description: "Estimate cycling FTP from recent activities with power. Results are cached for 7 days, so this can effectively be called only once every 7 days. Set save=true to write the estimate to Strava (only applied when a fresh, non-cached estimate is generated).",
         inputSchema: {
             type: "object",
             properties: {
@@ -215,8 +215,8 @@ const tools: ToolDef[] = [
             additionalProperties: false
         },
         handler: async (user, args) => {
-            const estimation = await getCachedFtpEstimate(user)
-            if (args.save) {
+            const {estimation, cached} = await getCachedFtpEstimate(user)
+            if (args.save && !cached) {
                 return estimation ? saveEstimatedFtp(user, args.ftp, estimation) : false
             }
             return estimation

--- a/src/mcp/utils.spec.ts
+++ b/src/mcp/utils.spec.ts
@@ -45,7 +45,9 @@ const sanitized: any = sanitizeUser({
     garmin: {id: "g1", tokens: {accessToken: "g"}},
     wahoo: {id: "w1", tokens: {accessToken: "w"}},
     spotify: {id: "s1", tokens: {accessToken: "s"}},
-    paddleId: "p1"
+    paddleId: "p1",
+    recipes: {recipe1: {title: "Morning ride"}},
+    fitDeviceNames: {"123": "Bike computer"}
 } as any)
 assert(!sanitized.stravaTokens, "Strava tokens are stripped")
 assert(!sanitized.urlToken, "Calendar URL token is stripped")
@@ -53,6 +55,8 @@ assert(!sanitized.garmin.tokens, "Garmin tokens are stripped")
 assert(!sanitized.wahoo.tokens, "Wahoo tokens are stripped")
 assert(!sanitized.spotify.tokens, "Spotify tokens are stripped")
 assert(!sanitized.paddleId, "Paddle ID is stripped")
+assert(!sanitized.recipes, "Automation recipes are stripped")
+assert(!sanitized.fitDeviceNames, "FIT device names are stripped")
 assert(sanitized.confirmEmail == "user@example.com", "Email confirmation token is stripped")
 assert(sanitized.garmin.id == "g1", "Garmin profile id is kept")
 

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -174,6 +174,8 @@ export const sanitizeUser = (user: UserData): any => {
     delete result.spotifyAuthState
     delete result.paddleId
     delete result.paddleTransactionId
+    delete result.recipes
+    delete result.fitDeviceNames
 
     if (result.confirmEmail) {
         result.confirmEmail = result.confirmEmail.substring(result.confirmEmail.indexOf(":") + 1)

--- a/src/routes/logic.ts
+++ b/src/routes/logic.ts
@@ -1,6 +1,6 @@
 // Shared handlers used by the HTTP API and the MCP tools.
 
-import {fitparser, gearwear, logHelper, recipes, strava, users, RecipeData, RecipeStatsData, StravaProcessedActivity, UserData} from "strautomator-core"
+import {fitparser, gearwear, logHelper, recipes, strava, users, RecipeData, RecipeStatsData, StravaEstimatedFtp, StravaProcessedActivity, UserData} from "strautomator-core"
 import {validateRecipeWebhookActions} from "../utils/urls"
 import dayjs from "../dayjs"
 import _ from "lodash"
@@ -185,8 +185,8 @@ export const getProcessedActivities = async (user: UserData, query?: {limit?: an
 /**
  * Save estimated FTP, same as POST /api/strava/:userId/ftp/estimate.
  */
-export const saveEstimatedFtp = async (user: UserData, ftp?: number): Promise<any> => {
-    const estimation = await strava.performance.estimateFtp(user)
+export const saveEstimatedFtp = async (user: UserData, ftp?: number, estimation?: StravaEstimatedFtp): Promise<any> => {
+    estimation = estimation || (await strava.performance.estimateFtp(user))
     if (ftp && ftp > 0) {
         estimation.ftpWatts = parseInt(ftp as any)
     }


### PR DESCRIPTION
## Summary
- exclude automation recipes and FIT device names from `get_account`
- add dedicated FIT device name and calendar metadata tools
- clarify GearWear battery tracking output and cache FTP estimates for seven days

## Testing
- `npx tsc --noEmit`
- `npx tsx src/mcp/utils.spec.ts`